### PR TITLE
Optimize meboot quantile sampling with sorted input

### DIFF
--- a/R/NNS_meboot.R
+++ b/R/NNS_meboot.R
@@ -164,7 +164,13 @@ NNS.meboot <- function(x,
   
   # Quantile draws from max-entropy bootstrap IN RESIDUAL SPACE
   res_mat <- matrix(rr, nrow = n, ncol = reps)
-  res_mat <- apply(res_mat, 2, NNS.meboot.part, n, z, xmin, xmax, desintxb, reachbnd)  
+  res_mat <- apply(
+    res_mat,
+    2,
+    function(col) {
+      NNS.meboot.part(xx, n, z, xmin, xmax, desintxb, reachbnd)
+    }
+  )
   qseq <- apply(res_mat, 2, sort)
   res_mat[ordxx, ] <- qseq
   

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -93,8 +93,8 @@ ARMA.seas.weighting <- function(sf, mat) {
     .Call(`_NNS_ARMA_seas_weighting`, sf, mat)
 }
 
-NNS.meboot.part <- function(x, n, z, xmin, xmax, desintxb, reachbnd) {
-    .Call(`_NNS_NNS_meboot_part`, x, n, z, xmin, xmax, desintxb, reachbnd)
+NNS.meboot.part <- function(xx, n, z, xmin, xmax, desintxb, reachbnd) {
+    .Call(`_NNS_NNS_meboot_part`, xx, n, z, xmin, xmax, desintxb, reachbnd)
 }
 
 NNS.meboot.expand.sd <- function(x, ensemble, fiv = 5.0) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -312,19 +312,19 @@ BEGIN_RCPP
 END_RCPP
 }
 // NNS_meboot_part
-NumericVector NNS_meboot_part(NumericVector x, int n, NumericVector z, double xmin, double xmax, NumericVector desintxb, bool reachbnd);
-RcppExport SEXP _NNS_NNS_meboot_part(SEXP xSEXP, SEXP nSEXP, SEXP zSEXP, SEXP xminSEXP, SEXP xmaxSEXP, SEXP desintxbSEXP, SEXP reachbndSEXP) {
+NumericVector NNS_meboot_part(NumericVector xx, int n, NumericVector z, double xmin, double xmax, NumericVector desintxb, bool reachbnd);
+RcppExport SEXP _NNS_NNS_meboot_part(SEXP xxSEXP, SEXP nSEXP, SEXP zSEXP, SEXP xminSEXP, SEXP xmaxSEXP, SEXP desintxbSEXP, SEXP reachbndSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< NumericVector >::type x(xSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type xx(xxSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type z(zSEXP);
     Rcpp::traits::input_parameter< double >::type xmin(xminSEXP);
     Rcpp::traits::input_parameter< double >::type xmax(xmaxSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type desintxb(desintxbSEXP);
     Rcpp::traits::input_parameter< bool >::type reachbnd(reachbndSEXP);
-    rcpp_result_gen = Rcpp::wrap(NNS_meboot_part(x, n, z, xmin, xmax, desintxb, reachbnd));
+    rcpp_result_gen = Rcpp::wrap(NNS_meboot_part(xx, n, z, xmin, xmax, desintxb, reachbnd));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/internal_functions.cpp
+++ b/src/internal_functions.cpp
@@ -375,12 +375,39 @@ List ARMA_seas_weighting(bool sf, SEXP mat) {
 // ---------- 8) NNS.meboot.part ----------
 
 // [[Rcpp::export(name = "NNS.meboot.part")]]
-NumericVector NNS_meboot_part(NumericVector x, int n, NumericVector z,
+NumericVector NNS_meboot_part(NumericVector xx, int n, NumericVector z,
                               double xmin, double xmax,
                               NumericVector desintxb, bool reachbnd) {
   NumericVector p = runif(n);
-  Function quantile("quantile");
-  NumericVector q = as<NumericVector>(quantile(x, _["probs"] = p));
+  int m = xx.size();
+  NumericVector q(n);
+
+  if (m == 0) {
+    std::fill(q.begin(), q.end(), NA_REAL);
+  } else if (m == 1) {
+    std::fill(q.begin(), q.end(), xx[0]);
+  } else {
+    for (int i = 0; i < n; ++i) {
+      double pi = p[i];
+      if (pi <= 0.0) {
+        q[i] = xx[0];
+        continue;
+      }
+      if (pi >= 1.0) {
+        q[i] = xx[m - 1];
+        continue;
+      }
+
+      double h = 1.0 + (m - 1.0) * pi;
+      int j = static_cast<int>(std::floor(h));
+      double g = h - static_cast<double>(j);
+
+      if (j < 1) j = 1;
+      if (j > m - 1) j = m - 1;
+
+      q[i] = (1.0 - g) * xx[j - 1] + g * xx[j];
+    }
+  }
   
   std::vector<int> ref1;
   double invn = 1.0 / (double)n;
@@ -400,13 +427,9 @@ NumericVector NNS_meboot_part(NumericVector x, int n, NumericVector z,
     }
   }
   
-  std::vector<int> ref4;
   double edge = (double)(n - 1) / (double)n;
-  for (int i = 0; i < p.size(); ++i) if (p[i] == edge) ref4.push_back(i);
-  for (int idx : ref4) q[idx] = z[n - 2];
-  
   std::vector<int> ref5;
-  for (int i = 0; i < p.size(); ++i) if (p[i] > edge) ref5.push_back(i);
+  for (int i = 0; i < p.size(); ++i) if (p[i] >= edge) ref5.push_back(i);
   if (!ref5.empty()) {
     NumericVector px(ref5.size());
     for (int i = 0; i < (int)ref5.size(); ++i) px[i] = p[ref5[i]];


### PR DESCRIPTION
### Motivation
- Reduce per-replicate R calls to `quantile` by computing type-7 quantiles in C++ from a pre-sorted input vector.
- Ensure correct handling of degenerate inputs (empty or single-value vectors) and simplify tail-case logic.

### Description
- Implemented an in-C++ type-7 quantile interpolation over a sorted `xx` vector in `NNS_meboot_part` and removed the R `quantile` call (`src/internal_functions.cpp`).
- Added explicit handling for `m == 0` and `m == 1` cases to return `NA_REAL` or the single value respectively (`src/internal_functions.cpp`).
- Simplified edge-tail logic by treating `p >= edge` for the upper tail and removed the separate equality special-case (`src/internal_functions.cpp`).
- Renamed the quantile input from `x` to `xx` and updated the R/C++ exports and R wrapper to pass the sorted residuals through: `src/RcppExports.cpp`, `R/RcppExports.R`, and `R/NNS_meboot.R`.

### Testing
- No automated tests were executed as part of this change.