### PR TITLE
Rewrite Partial Moments Equivalences example to match vignette style

### DIFF
--- a/examples/Partial Moments Equivalences.md
+++ b/examples/Partial Moments Equivalences.md
@@ -1,226 +1,210 @@
 ## Partial Moments Equivalences
-Below are some basic equivalences demonstrating partial moments' role as the elements of variance.
 
-### Why is this relevant?  
-The additional information generated from partial moments permits a level of analysis simply not possible with traditional summary statistics.
-There is further introductory material on partial moments and their extension into nonlinear analysis & behavioral finance applications available at:
+Why is it necessary to parse variance with partial moments? The additional information generated from partial moments permits a level of analysis that is not possible with traditional summary statistics alone.
 
-https://www.linkedin.com/pulse/elements-variance-fred-viole
+Below are basic equivalences that demonstrate partial moments as the elements of variance.
 
-
-## Installation
+### Installation
 ```r
-require(devtools); install_github('OVVO-Financial/NNS', ref = "NNS-Beta-Version")
+install.packages("NNS")
+```
+
+### Setup
+```r
+library(NNS)
+set.seed(123)
+x <- rnorm(100)
+y <- rnorm(100)
 ```
 
 ### Mean
-A difference between the upside area and the downside area of f(x).
-```r
-set.seed(123); x = rnorm(100); y = rnorm(100)
+A difference between the upside area and the downside area of `f(x)`.
 
-> mean(x)
-[1] 0.09040591
-> UPM(1,0,x)-LPM(1,0,x)
-[1] 0.09040591
+```r
+mean(x)
+UPM(1, 0, x) - LPM(1, 0, x)
 ```
+
 ### Variance
-A sum of the squared upside area and the squared downside area.
+A sum of the squared upside area and squared downside area.
+
 ```r
-# Sample Variance (base R):
-> var(x)
-[1] 0.8332328 
-> # Sample Variance:
-> (UPM(2, mean(x), x) + LPM(2, mean(x), x)) * (length(x) / (length(x) - 1))
-[1] 0.8332328
+# Sample variance (base R)
+var(x)
 
-# Population Adjustment of Sample Variance (base R):
-> var(x) * ((length(x) - 1) / length(x))
-[1] 0.8249005
+# Sample variance from partial moments
+(UPM(2, mean(x), x) + LPM(2, mean(x), x)) * (length(x) / (length(x) - 1))
 
-# Population Variance:
-> UPM(2, mean(x), x) + LPM(2, mean(x), x)
-[1] 0.8249005
+# Population adjustment of sample variance (base R)
+var(x) * ((length(x) - 1) / length(x))
 
-# Variance is also the co-variance of itself:
-> (Co.LPM(1, x, x, mean(x), mean(x)) + Co.UPM(1, x, x, mean(x), mean(x)) - D.LPM(1, 1, x, x, mean(x), mean(x)) - D.UPM(1, 1, x, x, mean(x), mean(x)))
-[1] 0.8249005
+# Population variance from partial moments
+UPM(2, mean(x), x) + LPM(2, mean(x), x)
+
+# Variance as covariance with itself
+Co.LPM(1, x, x, mean(x), mean(x)) +
+  Co.UPM(1, x, x, mean(x), mean(x)) -
+  D.LPM(1, 1, x, x, mean(x), mean(x)) -
+  D.UPM(1, 1, x, x, mean(x), mean(x))
 ```
 
-### The first 4 moments are returned with the function `NNS.moments`. For sample statistics, set `population = FALSE`.
+### First 4 Moments
+The first four moments are returned with `NNS.moments()`. For sample statistics, set `population = FALSE`.
+
 ```r
-> NNS.moments(x, population = FALSE)
-$mean
-[1] 0.09040591
-
-$variance
-[1] 0.8332328
-
-$skewness
-[1] 0.06235774
-
-$kurtosis
-[1] -0.1069186
-
-> NNS.moments(x, population = TRUE)
-$mean
-[1] 0.09040591
-
-$variance
-[1] 0.8249005
-
-$skewness
-[1] 0.06049948
-
-$kurtosis
-[1] -0.161053
+NNS.moments(x)
+NNS.moments(x, population = FALSE)
 ```
 
 ### Standard Deviation
 ```r
-> sd(x)
-[1] 0.9128159
-> ((UPM(2,mean(x),x)+LPM(2,mean(x),x))*(length(x)/(length(x)-1)))^.5
-[1] 0.9128159
-> sqrt(NNS.moments(x, population = FALSE)$variance)
-[1] 0.9128159
+sd(x)
+((UPM(2, mean(x), x) + LPM(2, mean(x), x)) * (length(x) / (length(x) - 1))) ^ 0.5
+sqrt(NNS.moments(x, population = FALSE)$variance)
 ```
+
 ### Covariance
 ```r
-> cov(x,y)
-[1] -0.04372107
-> (Co.LPM(1,x,y,mean(x),mean(y))+Co.UPM(1,x,y,mean(x),mean(y))-D.LPM(1,1,x,y,mean(x),mean(y))-D.UPM(1,1,x,y,mean(x),mean(y)))*(length(x)/(length(x)-1))
-[1] -0.04372107
+cov(x, y)
+(Co.LPM(1, x, y, mean(x), mean(y)) +
+  Co.UPM(1, x, y, mean(x), mean(y)) -
+  D.LPM(1, 1, x, y, mean(x), mean(y)) -
+  D.UPM(1, 1, x, y, mean(x), mean(y))) *
+  (length(x) / (length(x) - 1))
 ```
+
 ### Covariance Elements and Covariance Matrix
 The covariance matrix $(\Sigma)$ is equal to the sum of the co-partial moments matrices less the divergent partial moments matrices.
 
-$$\Sigma = CLPM + CUPM - DLPM - DUPM $$
-
+$$\Sigma = CLPM + CUPM - DLPM - DUPM$$
 
 ```r
-> cov.mtx = PM.matrix(LPM_degree = 1, UPM_degree = 1, target = 'mean', variable = cbind(x,y), pop_adj = TRUE)
-> cov.mtx
-$cupm
-          x         y
-x 0.4299250 0.1033601
-y 0.1033601 0.5411626
+cov.mtx <- PM.matrix(
+  LPM_degree = 1,
+  UPM_degree = 1,
+  target = "mean",
+  variable = cbind(x, y),
+  pop_adj = TRUE
+)
 
-$dupm
-          x         y
-x 0.0000000 0.1469182
-y 0.1560924 0.0000000
+cov.mtx
 
-$dlpm
-          x         y
-x 0.0000000 0.1560924
-y 0.1469182 0.0000000
+# Reassembled covariance matrix
+cov.mtx$clpm + cov.mtx$cupm - cov.mtx$dlpm - cov.mtx$dupm
 
-$clpm
-          x         y
-x 0.4033078 0.1559295
-y 0.1559295 0.3939005
-
-$cov.matrix
-            x           y
-x  0.83323283 -0.04372107
-y -0.04372107  0.93506310
-
-
-# Reassembled Covariance Matrix
-> cov.mtx$cupm + cov.mtx$clpm - cov.mtx$dupm - cov.mtx$dlpm
-            x           y
-x  0.83323283 -0.04372107
-y -0.04372107  0.93506310
-
-
-# Standard Covariance Matrix
-> cov(cbind(x,y))
-            x           y
-x  0.83323283 -0.04372107
-y -0.04372107  0.93506310
+# Standard covariance matrix
+cov(cbind(x, y))
 ```
-
 
 ### Pearson Correlation
 ```r
-> cor(x,y)
-[1] -0.04953215
-> cov.xy = (Co.LPM(1,x,y,mean(x),mean(y))+Co.UPM(1,x,y,mean(x),mean(y))-D.LPM(1,1,x,y,mean(x),mean(y))-D.UPM(1,1,x,y,mean(x),mean(y)))*(length(x)/(length(x)-1))
-> sd.x = ((UPM(2,mean(x),x)+LPM(2,mean(x),x))*(length(x)/(length(x)-1)))^.5
-> sd.y = ((UPM(2,mean(y),y)+LPM(2,mean(y),y))*(length(y)/(length(y)-1)))^.5
-> cov.xy/(sd.x*sd.y)
-[1] -0.04953215
+cor(x, y)
+
+cov.xy <- (Co.LPM(1, x, y, mean(x), mean(y)) +
+  Co.UPM(1, x, y, mean(x), mean(y)) -
+  D.LPM(1, 1, x, y, mean(x), mean(y)) -
+  D.UPM(1, 1, x, y, mean(x), mean(y))) *
+  (length(x) / (length(x) - 1))
+
+sd.x <- ((UPM(2, mean(x), x) + LPM(2, mean(x), x)) *
+  (length(x) / (length(x) - 1))) ^ 0.5
+
+sd.y <- ((UPM(2, mean(y), y) + LPM(2, mean(y), y)) *
+  (length(y) / (length(y) - 1))) ^ 0.5
+
+cov.xy / (sd.x * sd.y)
 ```
+
 ### Skewness
 A normalized difference between upside area and downside area.
+
 ```r
-> library(PerformanceAnalytics)
-> skewness(x)
-[1] 0.06049948
-> ((UPM(3,mean(x),x)-LPM(3,mean(x),x))/(UPM(2,mean(x),x)+LPM(2,mean(x),x))^(3/2))
-[1] 0.06049948
-> NNS.moments(x, population = TRUE)$skewness
-[1] 0.06049948
+PerformanceAnalytics::skewness(x)
+
+(UPM(3, mean(x), x) - LPM(3, mean(x), x)) /
+  (UPM(2, mean(x), x) + LPM(2, mean(x), x)) ^ (3 / 2)
+
+NNS.moments(x)$skewness
 ```
-### UPM/LPM - a more intuitive measure of skewness.  (Upside area / Downside area)
+
+### UPM / LPM Ratio
+A more intuitive skewness measure: upside area divided by downside area.
+
 ```r
-> UPM(2,mean(x),x)/LPM(2,mean(x),x)
-[1] 1.065997
+UPM(2, mean(x), x) / LPM(2, mean(x), x)
 ```
+
 ### Kurtosis
 A normalized sum of upside area and downside area.
+
 ```r
-> library(PerformanceAnalytics)
-> kurtosis(x)
-[1] -0.161053
-> ((UPM(4,mean(x),x)+LPM(4,mean(x),x))/(UPM(2,mean(x),x)+LPM(2,mean(x),x))^2)-3
-[1] -0.161053
-> NNS.moments(x, population = TRUE)$kurtosis
-[1] -0.161053
+PerformanceAnalytics::kurtosis(x)
+
+((UPM(4, mean(x), x) + LPM(4, mean(x), x)) /
+  (UPM(2, mean(x), x) + LPM(2, mean(x), x)) ^ 2) - 3
+
+NNS.moments(x)$kurtosis
 ```
+
 ### CDFs
 ```r
-> P = ecdf(x)
-> P(0); P(1)
-[1] 0.48
-[1] 0.83
-> LPM(0,0,x); LPM(0,1,x)
-[1] 0.48
-[1] 0.83
-# Vectorized targets:
-> LPM(0,c(0,1),x)
-[1] 0.48 0.83
-# Joint CDF:
-> Co.LPM(0,x,y,0,0)
-[1] 0.28
-# Vectorized targets:
-> Co.LPM(0,x,y,c(0,1),c(0,1))
-[1] 0.28 0.73
+P <- ecdf(x)
+P(0)
+P(1)
 
-# Alternatively via NNS.CDF()
-> NNS.CDF(x)
+LPM(0, 0, x)
+LPM(0, 1, x)
+
+# Vectorized targets
+LPM(0, c(0, 1), x)
+
+# Joint CDF
+Co.LPM(0, x, y, 0, 0)
+
+# Vectorized targets
+Co.LPM(0, x, y, c(0, 1), c(0, 1))
+
+# Continuous CDF and variants
+NNS.CDF(x, 1)
+NNS.CDF(x, 1, target = mean(x))
+NNS.CDF(x, 1, type = "survival")
 ```
+
 ### Copulas
 ```r
-# Transform x and y so that they are uniform
-u_x = LPM.ratio(0, x, x)
-u_y = LPM.ratio(0, y, y)
+# Transform x and y to uniform marginals
+u_x <- LPM.ratio(0, x, x)
+u_y <- LPM.ratio(0, y, y)
 
-# Value of copula at c(.5, .5)
-Co.LPM(0, u_x, u_y, .5, .5)
-[1] 0.26
+# Value of copula at c(0.5, 0.5)
+Co.LPM(0, u_x, u_y, 0.5, 0.5)
 ```
-### Numerical Integration - [UPM(1,0,f(x))-LPM(1,0,f(x))]=[F(b)-F(a)]/[b-a]
+
+### Numerical Integration
+Partial moments are asymptotic area approximations of `f(x)` akin to trapezoidal and Simpson's rules.
+
+$$[UPM(1,0,f(x)) - LPM(1,0,f(x))] \asymp \frac{F(b)-F(a)}{b-a}$$
+$$[UPM(1,0,f(x)) - LPM(1,0,f(x))] \cdot (b-a) \asymp F(b)-F(a)$$
+
 ```r
-# x is uniform sample over interval [a,b]; y = f(x)
-> x = seq(0,1,.001); y = x^2
-# [F(b)-F(a)] = [UPM(1,0,f(x))-LPM(1,0,f(x))] * [b-a] 
-> (UPM(1,0,y)-LPM(1,0,y)) * (1-0)
-[1] 0.3335
+x <- seq(0, 1, 0.001)
+y <- x ^ 2
+
+(UPM(1, 0, y) - LPM(1, 0, y)) * (1 - 0)
 ```
+
+For total area, not just the definite integral, sum the partial moments and multiply by `(b - a)`:
+
+$$[UPM(1,0,f(x)) + LPM(1,0,f(x))] \cdot (b-a) \asymp \left|\int_a^b f(x)dx\right|$$
 
 ### Bayes' Theorem
-```r
-See the following example explaining Bayes' Theorem and partial moments: 
-```
-https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Bayes'%20Theorem%20From%20Partial%20Moments.pdf
+For example, when ascertaining the probability of an increase in `A` given an increase in `B`, set `target_x = 0`, `target_y = 0`, and `target = 0`.
+
+$$P(A|B)=\frac{Co.UPM(0,0,A,B,0,0)}{UPM(0,0,B)}$$
+
+### References
+- [Nonlinear Nonparametric Statistics: Using Partial Moments](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/index.md)
+- [Cumulative Distribution Functions and UPM/LPM Analysis](https://doi.org/10.2139/ssrn.2148482)
+- [Continuous CDFs and ANOVA with NNS](https://doi.org/10.2139/ssrn.3007373)
+- [f(Newton)](https://doi.org/10.2139/ssrn.2186471)
+- [Bayes' Theorem From Partial Moments](https://doi.org/10.2139/ssrn.3457377)


### PR DESCRIPTION
### Motivation
- Align the example markdown with the `NNSvignette_Partial_Moments` narrative and section flow so users get a consistent learning experience.
- Replace transcript-style examples with clean, runnable R code blocks to make the document easier to copy-and-run and to reduce clutter from console prompts and printed outputs.
- Standardize formatting, assignment style, equation presentation, and the ordering of content (Installation → Setup → Mean → Variance → Moments → Covariance/Correlation → Distribution tools → Integration/Bayes → References).

### Description
- Rewrote `examples/Partial Moments Equivalences.md` to mirror the vignette structure and narrative tone, removing interactive console prompts and example outputs.
- Converted all examples to direct R code blocks using standard assignment syntax (e.g., `x <- rnorm(100)`) and organized sections for Mean, Variance, First 4 Moments, Standard Deviation, Covariance, Covariance matrix decomposition, Pearson correlation, Skewness, Kurtosis, CDFs, Copulas, Numerical Integration, Bayes' theorem, and References.
- Clarified equations and presentation for numerical integration and covariance decomposition, and included continuous CDF variants and copula examples formatted consistently.
- Cleaned up installation instructions and references for a modern, vignette-aligned README-style example.

### Testing
- The updated file content was inspected and compared against the partial moments vignette to confirm structural alignment and consistent code formatting, and this inspection succeeded.
- A repository state and diff check was performed to confirm only the intended example file was changed and the modifications were saved, and those checks succeeded.
- No automated unit tests or package test suite were modified or executed as part of this change.
