### PR TITLE
NNS 11.6.5 Beta

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -197,11 +197,13 @@ UPM.ratio <- function(degree, target, variable) {
 #' @description
 #'   Computes the co‑lower partial moment (lower‑left quadrant 4) between two
 #'   equal‑length numeric vectors at any degree and target.
-#' @param degree_lpm numeric; degree = 0 gives frequency, degree = 1 gives area.
+#' @param degree_lpm numeric; degree for x ("degree_x"). degree = 0 gives frequency, degree = 1 gives area.
 #' @param x numeric vector of observations.
 #' @param y numeric vector of the same length as x.
 #' @param target_x numeric vector; thresholds for x (defaults to mean(x)).
 #' @param target_y numeric vector; thresholds for y (defaults to mean(y)).
+#' @param degree_y numeric; optional degree for y. If omitted, `degree_lpm` is
+#'   used for both x and y.
 #' @return Numeric vector of co‑LPM values.
 #' @author Fred Viole, OVVO Financial Systems
 #' @references
@@ -211,8 +213,14 @@ UPM.ratio <- function(degree, target, variable) {
 #'   x <- rnorm(100); y <- rnorm(100)
 #'   Co.LPM(0, x, y, mean(x), mean(y))
 #' @export
-Co.LPM <- function(degree_lpm, x, y, target_x, target_y) {
-    .Call(`_NNS_CoLPM_RCPP`, degree_lpm, x, y, target_x, target_y)
+Co.LPM <- function(degree_lpm = NULL, x, y, target_x, target_y, degree_y = NULL) {
+    if (is.null(degree_lpm)) {
+        stop("degree_lpm must be supplied.")
+    }
+    if (is.null(degree_y)) {
+        degree_y <- degree_lpm
+    }
+    .Call(`_NNS_CoLPM_RCPP`, degree_lpm, degree_y, x, y, target_x, target_y)
 }
 
 #' @name Co.UPM
@@ -220,11 +228,13 @@ Co.LPM <- function(degree_lpm, x, y, target_x, target_y) {
 #' @description
 #'   Computes the co‑upper partial moment (upper‑right quadrant 1) between two
 #'   equal‑length numeric vectors at any degree and target.
-#' @param degree_upm numeric; degree = 0 gives frequency, degree = 1 gives area.
+#' @param degree_upm numeric; degree for x ("degree_x"). degree = 0 gives frequency, degree = 1 gives area.
 #' @param x numeric vector of observations.
 #' @param y numeric vector of the same length as x.
 #' @param target_x numeric vector; thresholds for x (defaults to mean(x)).
 #' @param target_y numeric vector; thresholds for y (defaults to mean(y)).
+#' @param degree_y numeric; optional degree for y. If omitted, `degree_upm` is
+#'   used for both x and y.
 #' @return Numeric vector of co‑UPM values.
 #' @author Fred Viole, OVVO Financial Systems
 #' @references
@@ -234,8 +244,14 @@ Co.LPM <- function(degree_lpm, x, y, target_x, target_y) {
 #'   x <- rnorm(100); y <- rnorm(100)
 #'   Co.UPM(0, x, y, mean(x), mean(y))
 #' @export
-Co.UPM <- function(degree_upm, x, y, target_x, target_y) {
-    .Call(`_NNS_CoUPM_RCPP`, degree_upm, x, y, target_x, target_y)
+Co.UPM <- function(degree_upm = NULL, x, y, target_x, target_y, degree_y = NULL) {
+    if (is.null(degree_upm)) {
+        stop("degree_upm must be supplied.")
+    }
+    if (is.null(degree_y)) {
+        degree_y <- degree_upm
+    }
+    .Call(`_NNS_CoUPM_RCPP`, degree_upm, degree_y, x, y, target_x, target_y)
 }
 
 #' @name D.LPM

--- a/man/Co.LPM.Rd
+++ b/man/Co.LPM.Rd
@@ -4,11 +4,13 @@
 \alias{Co.LPM}
 \title{Co‑Lower Partial Moment}
 \usage{
-Co.LPM(degree_lpm, x, y, target_x, target_y)
+Co.LPM(degree_lpm = NULL, x, y, target_x, target_y, degree_y = NULL)
 }
 \arguments{
-\item{degree_lpm}{numeric; degree = 0 gives frequency, degree = 1 gives area.}
+\item{degree_lpm}{numeric; degree for x ("degree_x"). degree = 0 gives frequency, degree = 1 gives area. Must be supplied in \code{Co.LPM()}.}
 
+
+\item{degree_y}{numeric; optional degree for y. If omitted, \code{degree_lpm} is used for both x and y.}
 \item{x}{numeric vector of observations.}
 
 \item{y}{numeric vector of the same length as x.}

--- a/man/Co.UPM.Rd
+++ b/man/Co.UPM.Rd
@@ -4,11 +4,13 @@
 \alias{Co.UPM}
 \title{Co‑Upper Partial Moment}
 \usage{
-Co.UPM(degree_upm, x, y, target_x, target_y)
+Co.UPM(degree_upm = NULL, x, y, target_x, target_y, degree_y = NULL)
 }
 \arguments{
-\item{degree_upm}{numeric; degree = 0 gives frequency, degree = 1 gives area.}
+\item{degree_upm}{numeric; degree for x ("degree_x"). degree = 0 gives frequency, degree = 1 gives area. Must be supplied in \code{Co.UPM()}.}
 
+
+\item{degree_y}{numeric; optional degree for y. If omitted, \code{degree_upm} is used for both x and y.}
 \item{x}{numeric vector of observations.}
 
 \item{y}{numeric vector of the same length as x.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -497,30 +497,32 @@ BEGIN_RCPP
 END_RCPP
 }
 // CoLPM_RCPP
-NumericVector CoLPM_RCPP(const double& degree_lpm, const RObject& x, const RObject& y, const RObject& target_x, const RObject& target_y);
-RcppExport SEXP _NNS_CoLPM_RCPP(SEXP degree_lpmSEXP, SEXP xSEXP, SEXP ySEXP, SEXP target_xSEXP, SEXP target_ySEXP) {
+NumericVector CoLPM_RCPP(const double& degree_lpm, const double& degree_y, const RObject& x, const RObject& y, const RObject& target_x, const RObject& target_y);
+RcppExport SEXP _NNS_CoLPM_RCPP(SEXP degree_lpmSEXP, SEXP degree_ySEXP, SEXP xSEXP, SEXP ySEXP, SEXP target_xSEXP, SEXP target_ySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const double& >::type degree_lpm(degree_lpmSEXP);
+    Rcpp::traits::input_parameter< const double& >::type degree_y(degree_ySEXP);
     Rcpp::traits::input_parameter< const RObject& >::type x(xSEXP);
     Rcpp::traits::input_parameter< const RObject& >::type y(ySEXP);
     Rcpp::traits::input_parameter< const RObject& >::type target_x(target_xSEXP);
     Rcpp::traits::input_parameter< const RObject& >::type target_y(target_ySEXP);
-    rcpp_result_gen = Rcpp::wrap(CoLPM_RCPP(degree_lpm, x, y, target_x, target_y));
+    rcpp_result_gen = Rcpp::wrap(CoLPM_RCPP(degree_lpm, degree_y, x, y, target_x, target_y));
     return rcpp_result_gen;
 END_RCPP
 }
 // CoUPM_RCPP
-NumericVector CoUPM_RCPP(const double& degree_upm, const RObject& x, const RObject& y, const RObject& target_x, const RObject& target_y);
-RcppExport SEXP _NNS_CoUPM_RCPP(SEXP degree_upmSEXP, SEXP xSEXP, SEXP ySEXP, SEXP target_xSEXP, SEXP target_ySEXP) {
+NumericVector CoUPM_RCPP(const double& degree_upm, const double& degree_y, const RObject& x, const RObject& y, const RObject& target_x, const RObject& target_y);
+RcppExport SEXP _NNS_CoUPM_RCPP(SEXP degree_upmSEXP, SEXP degree_ySEXP, SEXP xSEXP, SEXP ySEXP, SEXP target_xSEXP, SEXP target_ySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const double& >::type degree_upm(degree_upmSEXP);
+    Rcpp::traits::input_parameter< const double& >::type degree_y(degree_ySEXP);
     Rcpp::traits::input_parameter< const RObject& >::type x(xSEXP);
     Rcpp::traits::input_parameter< const RObject& >::type y(ySEXP);
     Rcpp::traits::input_parameter< const RObject& >::type target_x(target_xSEXP);
     Rcpp::traits::input_parameter< const RObject& >::type target_y(target_ySEXP);
-    rcpp_result_gen = Rcpp::wrap(CoUPM_RCPP(degree_upm, x, y, target_x, target_y));
+    rcpp_result_gen = Rcpp::wrap(CoUPM_RCPP(degree_upm, degree_y, x, y, target_x, target_y));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -622,8 +624,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_NNS_UPM_RCPP", (DL_FUNC) &_NNS_UPM_RCPP, 4},
     {"_NNS_LPM_ratio_RCPP", (DL_FUNC) &_NNS_LPM_ratio_RCPP, 3},
     {"_NNS_UPM_ratio_RCPP", (DL_FUNC) &_NNS_UPM_ratio_RCPP, 3},
-    {"_NNS_CoLPM_RCPP", (DL_FUNC) &_NNS_CoLPM_RCPP, 5},
-    {"_NNS_CoUPM_RCPP", (DL_FUNC) &_NNS_CoUPM_RCPP, 5},
+    {"_NNS_CoLPM_RCPP", (DL_FUNC) &_NNS_CoLPM_RCPP, 6},
+    {"_NNS_CoUPM_RCPP", (DL_FUNC) &_NNS_CoUPM_RCPP, 6},
     {"_NNS_DLPM_RCPP", (DL_FUNC) &_NNS_DLPM_RCPP, 6},
     {"_NNS_DUPM_RCPP", (DL_FUNC) &_NNS_DUPM_RCPP, 6},
     {"_NNS_PMMatrix_RCPP", (DL_FUNC) &_NNS_PMMatrix_RCPP, 6},

--- a/src/partial_moments.cpp
+++ b/src/partial_moments.cpp
@@ -356,7 +356,7 @@ NumericVector UPM_ratio_CPv(const double &degree, const NumericVector &target, c
 }
 
 double CoUPM_C(
-    const double &degree_lpm, const double &degree_upm, 
+    const double &degree_lpm, const double &degree_upm,
     const RVector<double> &x, const RVector<double> &y, 
     const double &target_x, const double &target_y 
 ){
@@ -369,30 +369,35 @@ double CoUPM_C(
     return 0;
   
   double out=0;
-  bool d_upm_0=(degree_upm==0);
+  bool d_x_0=(degree_lpm==0);
+  bool d_y_0=(degree_upm==0);
+  bool x_is_int=isInteger(degree_lpm);
+  bool y_is_int=isInteger(degree_upm);
   for(size_t i=0; i<min_size; i++){
     double x1=(x[i]-target_x);
     double y1=(y[i]-target_y);
     
-    if(d_upm_0){
-      x1 = (x1 > 0 ? 1 : 0);
-      y1 = (y1 > 0 ? 1 : 0);
-    } else {
-      x1 = (x1 < 0 ? 0 : x1);
-      y1 = (y1 < 0 ? 0 : y1);
+    if(d_x_0) x1 = (x1 > 0 ? 1 : 0);
+    else x1 = (x1 < 0 ? 0 : x1);
+
+    if(d_y_0) y1 = (y1 > 0 ? 1 : 0);
+    else y1 = (y1 < 0 ? 0 : y1);
+
+    if(!d_x_0){
+      if(x_is_int) x1 = repeatMultiplication(x1, static_cast<int>(degree_lpm));
+      else x1 = std::pow(x1, degree_lpm);
     }
-    
-    if(isInteger(degree_upm)){
-      if(d_upm_0) out += x1 * y1; 
-      else
-        out += repeatMultiplication(x1, static_cast<int>(degree_upm)) * repeatMultiplication(y1, static_cast<int>(degree_upm));
-    } else out += std::pow(x1, degree_upm) * std::pow(y1, degree_upm);
+    if(!d_y_0){
+      if(y_is_int) y1 = repeatMultiplication(y1, static_cast<int>(degree_upm));
+      else y1 = std::pow(y1, degree_upm);
+    }
+    out += x1 * y1;
   }
   return out/max_size;
 }
 
 double CoLPM_C(
-    const double &degree_lpm, const double &degree_upm, 
+    const double &degree_lpm, const double &degree_upm,
     const RVector<double> &x, const RVector<double> &y, 
     const double &target_x, const double &target_y 
 ){
@@ -404,24 +409,29 @@ double CoLPM_C(
   if (min_size<=0)
     return 0;
   double out=0;
-  bool d_lpm_0=(degree_lpm==0);
+  bool d_x_0=(degree_lpm==0);
+  bool d_y_0=(degree_upm==0);
+  bool x_is_int=isInteger(degree_lpm);
+  bool y_is_int=isInteger(degree_upm);
   for(size_t i=0; i<min_size; i++){
     double x1=(target_x-x[i]);
     double y1=(target_y-y[i]);
     
-    if(d_lpm_0){
-      x1 = (x1 >= 0 ? 1 : 0);
-      y1 = (y1 >= 0 ? 1 : 0);
-    } else {
-      x1 = (x1 < 0 ? 0 : x1);
-      y1 = (y1 < 0 ? 0 : y1);
+    if(d_x_0) x1 = (x1 >= 0 ? 1 : 0);
+    else x1 = (x1 < 0 ? 0 : x1);
+
+    if(d_y_0) y1 = (y1 >= 0 ? 1 : 0);
+    else y1 = (y1 < 0 ? 0 : y1);
+
+    if(!d_x_0){
+      if(x_is_int) x1 = repeatMultiplication(x1, static_cast<int>(degree_lpm));
+      else x1 = std::pow(x1, degree_lpm);
     }
-    
-    if(isInteger(degree_lpm)){
-      if(d_lpm_0) out += x1 * y1;
-      else
-        out += repeatMultiplication(x1, static_cast<int>(degree_lpm)) * repeatMultiplication(y1, static_cast<int>(degree_lpm));
-    } else out += std::pow(x1, degree_lpm) * std::pow(y1, degree_lpm);
+    if(!d_y_0){
+      if(y_is_int) y1 = repeatMultiplication(y1, static_cast<int>(degree_upm));
+      else y1 = std::pow(y1, degree_upm);
+    }
+    out += x1 * y1;
   }
   return out/max_size;
 }
@@ -519,18 +529,18 @@ WORKER_CLASS tmp_func(LPM_DEGREE_VARIABLE, UPM_DEGREE_VARIABLE, x, y, target_x, 
 parallelFor(0, output.size(), tmp_func);                                                            \
 return(output);
 NumericVector CoLPM_CPv(
-    const double &degree_lpm, 
-    const NumericVector &x, const NumericVector &y, 
+    const double &degree_x, const double &degree_y,
+    const NumericVector &x, const NumericVector &y,
     const NumericVector &target_x, const NumericVector &target_y
 ) {
-  NNS_CO_DE_LPM_UPM_PARALLEL_FOR_FUNC(CoLPM_Worker, degree_lpm, degree_lpm);
+  NNS_CO_DE_LPM_UPM_PARALLEL_FOR_FUNC(CoLPM_Worker, degree_x, degree_y);
 }
 NumericVector CoUPM_CPv(
-    const double &degree_upm, 
-    const NumericVector &x, const NumericVector &y, 
-    const NumericVector &target_x, const NumericVector &target_y 
+    const double &degree_x, const double &degree_y,
+    const NumericVector &x, const NumericVector &y,
+    const NumericVector &target_x, const NumericVector &target_y
 ) {
-  NNS_CO_DE_LPM_UPM_PARALLEL_FOR_FUNC(CoUPM_Worker, degree_upm, degree_upm);
+  NNS_CO_DE_LPM_UPM_PARALLEL_FOR_FUNC(CoUPM_Worker, degree_x, degree_y);
 }
 NumericVector DLPM_CPv(
     const double &degree_lpm, const double &degree_upm, 
@@ -566,8 +576,8 @@ void PMMatrix_Cv(
   RVector<double> x_rvec(x);
   RVector<double> y_rvec(y);
   
-  coLpm=CoLPM_C(degree_lpm, degree_upm, x_rvec, y_rvec, target_x, target_y);
-  coUpm=CoUPM_C(degree_lpm, degree_upm, x_rvec, y_rvec, target_x, target_y);
+  coLpm=CoLPM_C(degree_lpm, degree_lpm, x_rvec, y_rvec, target_x, target_y);
+  coUpm=CoUPM_C(degree_upm, degree_upm, x_rvec, y_rvec, target_x, target_y);
   dLpm=DLPM_C(degree_lpm, degree_upm, x_rvec, y_rvec, target_x, target_y);
   dUpm=DUPM_C(degree_lpm, degree_upm, x_rvec, y_rvec, target_x, target_y);
   covMat=0;

--- a/src/partial_moments.h
+++ b/src/partial_moments.h
@@ -114,12 +114,12 @@ NNS_PM_TWO_VARIABLES_WORKER(CoUPM_Worker, CoUPM_C);
 NNS_PM_TWO_VARIABLES_WORKER(DLPM_Worker, DLPM_C);
 NNS_PM_TWO_VARIABLES_WORKER(DUPM_Worker, DUPM_C);
 Rcpp::NumericVector CoLPM_CPv(
-    const double &degree_lpm,
+    const double &degree_x, const double &degree_y,
     const Rcpp::NumericVector &x, const Rcpp::NumericVector &y,
     const Rcpp::NumericVector &target_x, const Rcpp::NumericVector &target_y
 );
 Rcpp::NumericVector CoUPM_CPv(
-    const double &degree_upm,
+    const double &degree_x, const double &degree_y,
     const Rcpp::NumericVector &x, const Rcpp::NumericVector &y,
     const Rcpp::NumericVector &target_x, const Rcpp::NumericVector &target_y
 );

--- a/src/partial_moments_rcpp.cpp
+++ b/src/partial_moments_rcpp.cpp
@@ -214,11 +214,12 @@ NumericVector UPM_RCPP(const double &degree,
 //' @description
 //'   Computes the co‑lower partial moment (lower‑left quadrant 4) between two
 //'   equal‑length numeric vectors at any degree and target.
-//' @param degree_lpm numeric; degree = 0 gives frequency, degree = 1 gives area.
+//' @param degree_lpm numeric; degree for x ("degree_x"). degree = 0 gives frequency, degree = 1 gives area.
 //' @param x numeric vector of observations.
 //' @param y numeric vector of the same length as x.
 //' @param target_x numeric vector; thresholds for x (defaults to mean(x)).
 //' @param target_y numeric vector; thresholds for y (defaults to mean(y)).
+//' @param degree_y numeric; optional degree for y. If omitted, `degree_lpm` is used for both x and y.
 //' @return Numeric vector of co‑LPM values.
 //' @author Fred Viole, OVVO Financial Systems
 //' @references
@@ -230,8 +231,8 @@ NumericVector UPM_RCPP(const double &degree,
 //' @export
 // [[Rcpp::export("Co.LPM", rng = false)]]
  NumericVector CoLPM_RCPP(
-     const double &degree_lpm, 
-     const RObject &x, const RObject &y, 
+     const double &degree_lpm, const double &degree_y,
+     const RObject &x, const RObject &y,
      const RObject &target_x, const RObject &target_y
  ) {
    NumericVector target_x_vec, target_y_vec, x_vec, y_vec;
@@ -257,7 +258,7 @@ NumericVector UPM_RCPP(const double &degree,
      target_y_vec = NumericVector(1);
      target_y_vec[0] = mean(y_vec);
    }
-   return CoLPM_CPv(degree_lpm, x_vec, y_vec, target_x_vec, target_y_vec);
+   return CoLPM_CPv(degree_lpm, degree_y, x_vec, y_vec, target_x_vec, target_y_vec);
  }
 
 
@@ -266,11 +267,12 @@ NumericVector UPM_RCPP(const double &degree,
 //' @description
 //'   Computes the co‑upper partial moment (upper‑right quadrant 1) between two
 //'   equal‑length numeric vectors at any degree and target.
-//' @param degree_upm numeric; degree = 0 gives frequency, degree = 1 gives area.
+//' @param degree_upm numeric; degree for x ("degree_x"). degree = 0 gives frequency, degree = 1 gives area.
 //' @param x numeric vector of observations.
 //' @param y numeric vector of the same length as x.
 //' @param target_x numeric vector; thresholds for x (defaults to mean(x)).
 //' @param target_y numeric vector; thresholds for y (defaults to mean(y)).
+//' @param degree_y numeric; optional degree for y. If omitted, `degree_upm` is used for both x and y.
 //' @return Numeric vector of co‑UPM values.
 //' @author Fred Viole, OVVO Financial Systems
 //' @references
@@ -282,8 +284,8 @@ NumericVector UPM_RCPP(const double &degree,
 //' @export
 // [[Rcpp::export("Co.UPM", rng = false)]]
  NumericVector CoUPM_RCPP(
-     const double &degree_upm, 
-     const RObject &x, const RObject &y, 
+     const double &degree_upm, const double &degree_y,
+     const RObject &x, const RObject &y,
      const RObject &target_x, const RObject &target_y
  ) {
    NumericVector target_x_vec, target_y_vec, x_vec, y_vec;
@@ -309,7 +311,7 @@ NumericVector UPM_RCPP(const double &degree,
      target_y_vec = NumericVector(1);
      target_y_vec[0] = mean(y_vec);
    }
-   return CoUPM_CPv(degree_upm, x_vec, y_vec, target_x_vec, target_y_vec);
+   return CoUPM_CPv(degree_upm, degree_y, x_vec, y_vec, target_x_vec, target_y_vec);
  }
 
 

--- a/src/partial_moments_rcpp.h
+++ b/src/partial_moments_rcpp.h
@@ -26,11 +26,13 @@ Rcpp::NumericVector UPM_ratio_RCPP(const double &degree,
                                    const Rcpp::RObject &target,
                                    const Rcpp::RObject &variable);
 Rcpp::NumericVector CoLPM_RCPP(const double &degree_lpm,
+                               const double &degree_y,
                                const Rcpp::RObject &x,
                                const Rcpp::RObject &y,
                                const Rcpp::RObject &target_x,
                                const Rcpp::RObject &target_y);
 Rcpp::NumericVector CoUPM_RCPP(const double &degree_upm,
+                               const double &degree_y,
                                const Rcpp::RObject &x,
                                const Rcpp::RObject &y,
                                const Rcpp::RObject &target_x,


### PR DESCRIPTION
### Motivation
- Make `Co.LPM()` consistent with the recently-updated `Co.UPM()` by treating the existing `degree_lpm` as the x-degree (`degree_x`) and exposing an optional `degree_y` so callers can specify asymmetric exponents for x and y.
- Preserve backward compatibility for single-degree calls by defaulting `degree_y` to `degree_lpm` when omitted and keep PM matrix behavior unchanged.

### Description
- Updated the R API: `Co.LPM()` now accepts `degree_y = NULL` and sets `degree_y <- degree_lpm` when omitted, and the `.Call()` invocation now passes both degrees (`degree_lpm, degree_y`).
- Updated documentation and roxygen: `R/RcppExports.R`, `man/Co.LPM.Rd`, and the roxygen block in `src/partial_moments_rcpp.cpp` now describe `degree_lpm` as `degree_x` and the new optional `degree_y` argument.
- Wired the two-degree API through the compiled layer: `CoLPM_RCPP` signature updated to accept `(degree_lpm, degree_y, x, y, target_x, target_y)`, `_NNS_CoLPM_RCPP` registration arity updated, and `src/partial_moments_rcpp.h`/`src/RcppExports.cpp` updated accordingly.
- Implemented asymmetric exponent behavior in the core: `CoLPM_CPv` now forwards `(degree_x, degree_y)` and `CoLPM_C` applies the x-degree to the x-term and the y-degree to the y-term (including degree==0 boolean handling and integer-exponent optimization), while PMMatrix calls remain symmetric (use `degree_lpm` for both x and y) to retain historical matrix semantics.

### Testing
- Verified interface and signature wiring across R/C++ layers with `rg "Co\.LPM <- function|CoLPM_RCPP\(|_NNS_CoLPM_RCPP|degree_y|CoLPM_CPv\("` (succeeded).
- Ran whitespace/lint check with `git diff --check` to ensure no trailing-space issues (succeeded).
- Attempted an R runtime sanity check (`Rscript -e "source('R/RcppExports.R')"`) but `Rscript` is not available in the environment so runtime compilation/execution was skipped.
