### PR TITLE
NNS 11.6.5 Beta

### DIFF
--- a/src/partial_moments.cpp
+++ b/src/partial_moments.cpp
@@ -634,6 +634,8 @@ List PMMatrix_CPv(
         } else {
           coUpm(i, j) = dUpm(i, j) = dLpm(i, j) = coLpm(i, j) = 0.0;
         }
+
+        covMat(i, j) = coUpm(i, j) + coLpm(i, j) - dUpm(i, j) - dLpm(i, j);
       }
     }
   }

--- a/tests/testthat/test_Partial_Moments.R
+++ b/tests/testthat/test_Partial_Moments.R
@@ -176,6 +176,20 @@ test_that(
   }
 )
 
+test_that(
+  "NNS::PM.matrix - norm TRUE returns signed normalized covariance decomposition", {
+    A <- cbind(x, y, z)
+    pm <- NNS::PM.matrix(1, 1, NULL, A, pop_adj = TRUE, norm = TRUE)
+
+    expect_equal(
+      pm$cov.matrix,
+      pm$cupm + pm$clpm - pm$dlpm - pm$dupm,
+      tolerance = 1e-10
+    )
+    expect_equal(diag(pm$cov.matrix), rep(1, ncol(A)), tolerance = 1e-10)
+  }
+)
+
 #########################################################################
 # CDF
 


### PR DESCRIPTION
### Motivation
- `PM.matrix(..., norm = TRUE)` was normalizing the four quadrant matrices cell-wise but left `cov.matrix` unchanged, producing inconsistent output where the normalized quadrants no longer reconstruct the reported `cov.matrix`.
- The intended normalized output should present per-cell shares (sum = 1 across the four quadrants) while `cov.matrix` reflects the signed decomposition `cupm + clpm - dupm - dlpm` using those normalized values.

### Description
- Recompute the covariance output after normalization by assigning `covMat(i, j) = coUpm(i, j) + coLpm(i, j) - dUpm(i, j) - dLpm(i, j)` inside `PMMatrix_CPv` when `norm` is `TRUE` in `src/partial_moments.cpp`.
- Add a regression test in `tests/testthat/test_Partial_Moments.R` that constructs `pm <- PM.matrix(..., norm = TRUE)` and asserts `pm$cov.matrix == pm$cupm + pm$clpm - pm$dlpm - pm$dupm` and that the diagonal of the normalized `cov.matrix` equals 1.

### Testing
- Added a unit test asserting the normalized decomposition and unit diagonal in `tests/testthat/test_Partial_Moments.R` but the test suite could not be executed in this environment because `R`/`Rscript` is not installed and `testthat::test_file('...')` failed with `command not found`.
- Performed a code inspection to verify the new `covMat` assignment is present and that the test asserts the expected relationships, however no automated R tests ran successfully here due to the missing runtime.
