### PR TITLE
Publish bookdown output to GitHub Pages

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,12 +33,24 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown, any::bookdown, local::.
           needs: website
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
+
+      - name: Build book
+        run: |
+          old <- setwd("book")
+          on.exit(setwd(old), add = TRUE)
+          bookdown::render_book("index.Rmd", output_format = "bookdown::gitbook")
+        shell: Rscript {0}
+
+      - name: Stage book for Pages
+        run: |
+          mkdir -p docs/book
+          rsync -a --delete book/_book/ docs/book/
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
### Motivation
- Ensure the rendered book is included in the GitHub Pages site so the book is accessible at `/NNS/book/` on the project Pages site.
- Combine the package site (pkgdown) and the book (bookdown) in the CI deployment so the book is built and staged into the `docs/` folder that is deployed to `gh-pages`.

### Description
- Add `any::bookdown` to the workflow `setup-r-dependencies` `extra-packages` so `bookdown` is available in CI.
- Add a `Build book` step that runs `bookdown::render_book("index.Rmd", output_format = "bookdown::gitbook")` from the `book` directory.
- Add a `Stage book for Pages` step that copies the rendered output from `book/_book/` into `docs/book/` so it will be deployed with the existing `docs` site.

### Testing
- Parsed the updated workflow YAML with Ruby (`ruby -e 'require "yaml"; ...'`) and confirmed the workflow name and step count, which succeeded.
- Inspected the workflow file with `sed -n` and `nl -ba` to verify the new `Build book` and `Stage book for Pages` steps are present, which succeeded.
- Attempted a Python YAML parse with `PyYAML` which failed due to `PyYAML` not being installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6fdd7d4fc832d8ca7b2c0c60cfa99)