### PR TITLE
Optimize NNS.dep matrix computation

### DIFF
--- a/R/Dependence.R
+++ b/R/Dependence.R
@@ -131,24 +131,34 @@ NNS.dep <- function(x,
   
   l   <- length(x)
   obs <- max(8L, as.integer(l / 8L))
-  
-  PART_xy <- suppressWarnings(
-    NNS.part(x, y, order = NULL, obs.req = obs,
-             min.obs.stop = FALSE, type = "XONLY", Voronoi = print.map)
-  )
-  PART_yx <- suppressWarnings(
-    NNS.part(y, x, order = NULL, obs.req = obs,
-             min.obs.stop = FALSE, type = "XONLY", Voronoi = FALSE)
-  )
-  
-  if (nrow(PART_xy$regression.points) == 0L)
-    return(list("Correlation" = 0, "Dependence" = 0))
+  x_num <- as.numeric(x)
+  y_num <- as.numeric(y)
+
+  if (isTRUE(print.map)) {
+    PART_xy <- suppressWarnings(
+      NNS.part(x, y, order = NULL, obs.req = obs,
+               min.obs.stop = FALSE, type = "XONLY", Voronoi = TRUE)
+    )
+    PART_yx <- suppressWarnings(
+      NNS.part(y, x, order = NULL, obs.req = obs,
+               min.obs.stop = FALSE, type = "XONLY", Voronoi = FALSE)
+    )
+
+    if (nrow(PART_xy$regression.points) == 0L)
+      return(list("Correlation" = 0, "Dependence" = 0))
+
+    quad_xy <- PART_xy$dt$quadrant
+    quad_yx <- PART_yx$dt$quadrant
+  } else {
+    quad_xy <- NNS_part_cpp(x_num, y_num, "XONLY", NULL, obs, FALSE, "off", TRUE)$quadrant
+    quad_yx <- NNS_part_cpp(y_num, x_num, "XONLY", NULL, obs, FALSE, "off", TRUE)$quadrant
+  }
   
   NNS_dep_pair_cpp(
-    x       = as.numeric(x),
-    y       = as.numeric(y),
-    quad_xy = as.character(PART_xy$dt$quadrant),
-    quad_yx = as.character(PART_yx$dt$quadrant),
+    x       = x_num,
+    y       = y_num,
+    quad_xy = as.character(quad_xy),
+    quad_yx = as.character(quad_yx),
     asym    = isTRUE(asym)
   )
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -25,8 +25,8 @@ NNS_distance_path_parallel_cpp <- function(RPM, yhat, Xtest, kmax, is_class, nth
     .Call(`_NNS_NNS_distance_path_parallel_cpp`, RPM, yhat, Xtest, kmax, is_class, nthreads)
 }
 
-NNS_part_cpp <- function(x, y, type, order_in, obs_req, min_obs_stop, noise_reduction) {
-    .Call(`_NNS_NNS_part_cpp`, x, y, type, order_in, obs_req, min_obs_stop, noise_reduction)
+NNS_part_cpp <- function(x, y, type, order_in, obs_req, min_obs_stop, noise_reduction, quadrants_only = FALSE) {
+    .Call(`_NNS_NNS_part_cpp`, x, y, type, order_in, obs_req, min_obs_stop, noise_reduction, quadrants_only)
 }
 
 NNS_seas_cpp <- function(variable, modulo = NULL, mod_only = TRUE) {

--- a/src/NNS_dep.cpp
+++ b/src/NNS_dep.cpp
@@ -15,9 +15,8 @@
 //   trial and epoch in NNS.boost / NNS.stack.
 //
 //   This file eliminates every one of those dispatches.  The per-quadrant
-//   copula computation (copula_signed) calls CoLPM_C / CoUPM_C / DLPM_C /
-//   DUPM_C / clpm_nD_cpp / cupm_nD_cpp / dpm_nD_cpp directly -- all already
-//   C++ internal-linkage functions in partial_moments.cpp / partial_moments.h.
+//   copula computation is evaluated directly for the bivariate degree-0 and
+//   degree-1 partial moment terms used by NNS.dep.
 //
 //   Discrete-variable correction (triggered when both x and y have fewer
 //   unique values than sqrt(n)):
@@ -38,8 +37,6 @@
 #include <unordered_map>
 #include <algorithm>
 #include <numeric>
-#include "partial_moments.h"    // CoLPM_C, CoUPM_C, DLPM_C, DUPM_C
-// clpm_nD_cpp, cupm_nD_cpp, dpm_nD_cpp
 #include "central_tendencies.h" // NNS_gravity_cpp
 
 using namespace Rcpp;
@@ -54,26 +51,6 @@ static inline double gravity_cpp(const std::vector<double>& v) {
   if (v.empty()) return NA_REAL;
   NumericVector nv(v.begin(), v.end());
   return as<double>(NNS_gravity_cpp(nv, false));
-}
-
-// Sign of OLS slope: replicates sign(fast_lm(x, y)$coef[2])
-// Returns exactly -1.0, 0.0, or +1.0
-static inline double ols_sign(const std::vector<double>& x,
-                              const std::vector<double>& y) {
-  int n = static_cast<int>(x.size());
-  if (n < 2) return 0.0;
-  double mx = 0.0, my = 0.0;
-  for (int i = 0; i < n; ++i) { mx += x[i]; my += y[i]; }
-  mx /= n; my /= n;
-  double cov = 0.0, varx = 0.0;
-  for (int i = 0; i < n; ++i) {
-    double dx = x[i] - mx;
-    cov  += dx * (y[i] - my);
-    varx += dx * dx;
-  }
-  if (varx == 0.0) return 0.0;
-  double s = cov / varx;
-  return (s > 0.0) ? 1.0 : (s < 0.0) ? -1.0 : 0.0;
 }
 
 // Count distinct values in a std::vector<double>
@@ -112,54 +89,51 @@ static double copula_signed(const std::vector<double>& xv,
   int n = static_cast<int>(xv.size());
   if (n < 2) return 0.0;
   
-  // targets = column means
   double tx = 0.0, ty = 0.0;
   for (int i = 0; i < n; ++i) { tx += xv[i]; ty += yv[i]; }
   tx /= n; ty /= n;
   
-  // Build RVector views for the scalar C functions
-  NumericVector xnv(xv.begin(), xv.end());
-  NumericVector ynv(yv.begin(), yv.end());
-  RVector<double> xrv(xnv), yrv(ynv);
-  
-  // --- degree-0 pairwise moments (pop_adj = FALSE) ---
-  double d0_cupm = CoUPM_C(0.0, 0.0, xrv, yrv, tx, ty);
-  double d0_clpm = CoLPM_C(0.0, 0.0, xrv, yrv, tx, ty);
-  
-  // early-return guard (matches NNS.copula: if(Co_pm==1||Co_pm==0) return(1))
-  double d0_Co = d0_cupm + d0_clpm;
-  if (d0_Co == 1.0 || d0_Co == 0.0) return 1.0;
-  
-  // --- degree-1 pairwise moments (pop_adj = TRUE, then normalise) ---
-  double adj = static_cast<double>(n) / static_cast<double>(n - 1);
-  double c1_cupm = CoUPM_C(1.0, 1.0, xrv, yrv, tx, ty) * adj;
-  double c1_clpm = CoLPM_C(1.0, 1.0, xrv, yrv, tx, ty) * adj;
-  double c1_dlpm = DLPM_C (1.0, 1.0, xrv, yrv, tx, ty) * adj;
-  double c1_dupm = DUPM_C (1.0, 1.0, xrv, yrv, tx, ty) * adj;
-  {
-    double tot = c1_cupm + c1_dupm + c1_dlpm + c1_clpm;
-    if (tot > 0.0) {
-      c1_cupm /= tot; c1_clpm /= tot;
-      c1_dlpm /= tot; c1_dupm /= tot;
+  double d0_cupm = 0.0, d0_clpm = 0.0, dpm_d0_count = 0.0;
+  double c1_cupm = 0.0, c1_clpm = 0.0, c1_dpm = 0.0;
+  double cov = 0.0, varx = 0.0;
+
+  for (int i = 0; i < n; ++i) {
+    double dx = xv[i] - tx;
+    double dy = yv[i] - ty;
+
+    if (dx > 0.0 && dy > 0.0) d0_cupm += 1.0;
+    if (dx <= 0.0 && dy <= 0.0) d0_clpm += 1.0;
+    if (!((dx < 0.0 && dy < 0.0) || (dx > 0.0 && dy > 0.0)))
+      dpm_d0_count += 1.0;
+
+    if (dx >= 0.0 && dy >= 0.0) {
+      c1_cupm += dx * dy;
+    } else if (dx <= 0.0 && dy <= 0.0) {
+      c1_clpm += dx * dy;
+    } else {
+      c1_dpm += std::abs(dx) * std::abs(dy);
     }
+
+    cov += dx * dy;
+    varx += dx * dx;
   }
   
-  // --- n-dimensional partial moments (2D matrix) ---
-  NumericMatrix data(n, 2);
-  for (int i = 0; i < n; ++i) { data(i, 0) = xv[i]; data(i, 1) = yv[i]; }
-  NumericVector tgt = NumericVector::create(tx, ty);
+  double inv_n = 1.0 / static_cast<double>(n);
+  double d0_Co = (d0_cupm + d0_clpm) * inv_n;
+  if (d0_Co == 1.0 || d0_Co == 0.0) return 1.0;
   
-  double dpm_d0 = dpm_nD_cpp(data, tgt, 0.0, true);
-  double dpm_d1 = dpm_nD_cpp(data, tgt, 1.0, true);
+  double c1_total = c1_cupm + c1_clpm + c1_dpm;
+  double co_d1 = c1_total > 0.0 ? (c1_cupm + c1_clpm) / c1_total : 0.0;
+  double dpm_d0 = dpm_d0_count * inv_n;
+  double dpm_d1 = c1_total > 0.0 ? c1_dpm / c1_total : 0.0;
   
-  // --- four dependence terms ---
   constexpr double indep_Co = 0.5;   // 0.25*(2^2-2) for n=2 cols
   constexpr double indep_D  = 0.75;  // 1 - 0.5^2   for n=2 cols
   
   double discrete_dep   = std::min(1.0, std::max(0.0,
                                                  std::abs(d0_Co              - indep_Co) / indep_Co));
   double continuous_dep = std::min(1.0, std::max(0.0,
-                                                 std::abs(c1_cupm + c1_clpm  - indep_Co) / indep_Co));
+                                                 std::abs(co_d1              - indep_Co) / indep_Co));
   double nd_disc_dep    = std::abs(dpm_d0 - indep_D) / indep_D;
   double nd_cont_dep    = std::abs(dpm_d1 - indep_D) / indep_D;
   
@@ -167,7 +141,8 @@ static double copula_signed(const std::vector<double>& xv,
     (discrete_dep + continuous_dep + nd_disc_dep + nd_cont_dep) / 4.0
   );
   
-  return copula_val * ols_sign(xv, yv);
+  double slope_sign = varx == 0.0 ? 0.0 : ((cov > 0.0) ? 1.0 : (cov < 0.0) ? -1.0 : 0.0);
+  return copula_val * slope_sign;
 }
 
 // ============================================================
@@ -190,18 +165,19 @@ static double copula_degree0_unsigned(const std::vector<double>& xv,
   for (int i = 0; i < n; ++i) { tx += xv[i]; ty += yv[i]; }
   tx /= n; ty /= n;
   
-  NumericVector xnv(xv.begin(), xv.end());
-  NumericVector ynv(yv.begin(), yv.end());
-  RVector<double> xrv(xnv), yrv(ynv);
+  double d0_cupm = 0.0, d0_clpm = 0.0, dpm_d0_count = 0.0;
+  for (int i = 0; i < n; ++i) {
+    double dx = xv[i] - tx;
+    double dy = yv[i] - ty;
+    if (dx > 0.0 && dy > 0.0) d0_cupm += 1.0;
+    if (dx <= 0.0 && dy <= 0.0) d0_clpm += 1.0;
+    if (!((dx < 0.0 && dy < 0.0) || (dx > 0.0 && dy > 0.0)))
+      dpm_d0_count += 1.0;
+  }
   
-  double d0_cupm = CoUPM_C(0.0, 0.0, xrv, yrv, tx, ty);
-  double d0_clpm = CoLPM_C(0.0, 0.0, xrv, yrv, tx, ty);
-  double d0_Co   = d0_cupm + d0_clpm;
-  
-  NumericMatrix data(n, 2);
-  for (int i = 0; i < n; ++i) { data(i, 0) = xv[i]; data(i, 1) = yv[i]; }
-  NumericVector tgt = NumericVector::create(tx, ty);
-  double dpm_d0 = dpm_nD_cpp(data, tgt, 0.0, true);
+  double inv_n = 1.0 / static_cast<double>(n);
+  double d0_Co = (d0_cupm + d0_clpm) * inv_n;
+  double dpm_d0 = dpm_d0_count * inv_n;
   
   constexpr double indep_Co = 0.5;
   constexpr double indep_D  = 0.75;

--- a/src/NNS_part.cpp
+++ b/src/NNS_part.cpp
@@ -61,7 +61,8 @@ List NNS_part_cpp(NumericVector x,
                   Nullable<int> order_in,
                   int obs_req,
                   bool min_obs_stop,
-                  std::string noise_reduction){
+                  std::string noise_reduction,
+                  bool quadrants_only = false){
   
   const int n=x.size();
   if(y.size()!=n) stop("x and y must have same length");
@@ -123,7 +124,7 @@ List NNS_part_cpp(NumericVector x,
     }
     
     // -------------------- NEW: record ablines for XONLY at this depth ----------
-    if(xonly){
+    if(xonly && !quadrants_only){
       for(auto &kv: grp){
         const auto &idx = kv.second;
         double minx=R_PosInf, maxx=R_NegInf;
@@ -165,8 +166,12 @@ List NNS_part_cpp(NumericVector x,
   }
   
   // assemble results
-  CharacterVector q_cur(n), q_prior(n);
-  for(int i=0;i<n;++i){ q_cur[i]=quadrant[i]; q_prior[i]=prior_quadrant[i]; }
+  CharacterVector q_cur(n);
+  for(int i=0;i<n;++i) q_cur[i]=quadrant[i];
+  if(quadrants_only) return List::create(_["quadrant"]=q_cur);
+
+  CharacterVector q_prior(n);
+  for(int i=0;i<n;++i) q_prior[i]=prior_quadrant[i];
   DataFrame part = DataFrame::create(_["x"]=x,_["y"]=y,_["quadrant"]=q_cur,
                                      _["prior.quadrant"]=q_prior,
                                      _["stringsAsFactors"]=false);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -99,8 +99,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // NNS_part_cpp
-List NNS_part_cpp(NumericVector x, NumericVector y, Nullable<std::string> type, Nullable<int> order_in, int obs_req, bool min_obs_stop, std::string noise_reduction);
-RcppExport SEXP _NNS_NNS_part_cpp(SEXP xSEXP, SEXP ySEXP, SEXP typeSEXP, SEXP order_inSEXP, SEXP obs_reqSEXP, SEXP min_obs_stopSEXP, SEXP noise_reductionSEXP) {
+List NNS_part_cpp(NumericVector x, NumericVector y, Nullable<std::string> type, Nullable<int> order_in, int obs_req, bool min_obs_stop, std::string noise_reduction, bool quadrants_only);
+RcppExport SEXP _NNS_NNS_part_cpp(SEXP xSEXP, SEXP ySEXP, SEXP typeSEXP, SEXP order_inSEXP, SEXP obs_reqSEXP, SEXP min_obs_stopSEXP, SEXP noise_reductionSEXP, SEXP quadrants_onlySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -111,7 +111,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type obs_req(obs_reqSEXP);
     Rcpp::traits::input_parameter< bool >::type min_obs_stop(min_obs_stopSEXP);
     Rcpp::traits::input_parameter< std::string >::type noise_reduction(noise_reductionSEXP);
-    rcpp_result_gen = Rcpp::wrap(NNS_part_cpp(x, y, type, order_in, obs_req, min_obs_stop, noise_reduction));
+    Rcpp::traits::input_parameter< bool >::type quadrants_only(quadrants_onlySEXP);
+    rcpp_result_gen = Rcpp::wrap(NNS_part_cpp(x, y, type, order_in, obs_req, min_obs_stop, noise_reduction, quadrants_only));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -632,7 +633,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_NNS_NNS_distance_path_cpp", (DL_FUNC) &_NNS_NNS_distance_path_cpp, 5},
     {"_NNS_NNS_distance_bulk_cpp", (DL_FUNC) &_NNS_NNS_distance_bulk_cpp, 5},
     {"_NNS_NNS_distance_path_parallel_cpp", (DL_FUNC) &_NNS_NNS_distance_path_parallel_cpp, 6},
-    {"_NNS_NNS_part_cpp", (DL_FUNC) &_NNS_NNS_part_cpp, 7},
+    {"_NNS_NNS_part_cpp", (DL_FUNC) &_NNS_NNS_part_cpp, 8},
     {"_NNS_NNS_seas_cpp", (DL_FUNC) &_NNS_NNS_seas_cpp, 3},
     {"_NNS_sd_dom_matrix_prefix_parallel", (DL_FUNC) &_NNS_sd_dom_matrix_prefix_parallel, 3},
     {"_NNS_NNS_SD_efficient_set_parallel_cpp", (DL_FUNC) &_NNS_NNS_SD_efficient_set_parallel_cpp, 4},


### PR DESCRIPTION
I profiled `NNS.dep` and found most of the time was in the pairwise matrix path.

This seems relevant to larger-universe finance workflows, like S&P-style portfolios / dispersion metrics where we keep doing pairwise dependence work across many constituents.

The main profiling result was that the normal matrix path (`print.map = FALSE`) does not need the full partition/map output for each pair; it only needs the quadrant labels plus the final bivariate dependence calculation.

This PR keeps the public R API unchanged, but avoids extra internal work in that non-plotting path:

- only fetches XONLY quadrant labels instead of building the full `NNS.part` output
- computes the bivariate degree-0 / degree-1 copula terms directly in one C++ pass
- still builds the full `NNS.part` output when `print.map = TRUE`

Since `print.map = FALSE` is the documented default, that is where I focused the main benchmark. With `print.map = TRUE`, I still saw smaller gains from the C++ copula path (~15-20% faster on S&P-style pairs), but the full map construction remains the main cost.

Local A/B on my PC, using daily return matrices and `print.map = FALSE`:

| Data | Pairwise calls | Old | New |
| --- | ---: | ---: | ---: |
| S&P-style fixture, 252 daily rows x 100 cols | 4,950 | 30.6s | 2.0s |
| S&P-style fixture, 252 daily rows x 200 cols | 19,900 | 123.7s | 6.1s |
| S&P-style fixture, 126 daily rows x 400 cols | 79,800 | 516.1s | 16.7s |
| S&P-style fixture, 63 daily rows x 478 cols | 114,003 | 1042.3s | 17.5s |

Outputs matched within floating-point roundoff across my test cases. Package test files passed locally.

This touches more internals than the prior PR, so I’d appreciate an extra look from someone more familiar with the codebase.