### PR TITLE
Fix downstream sync changed-file detection for multi-commit pushes

### DIFF
--- a/.github/workflows/downstream-sync-dispatch.yml
+++ b/.github/workflows/downstream-sync-dispatch.yml
@@ -1,0 +1,118 @@
+name: Downstream sync dispatch
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  detect-and-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out R NNS repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect upstream changes
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "push" ] && [ -n "${{ github.event.before }}" ]; then
+            git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" > changed_files.txt
+          elif git rev-parse HEAD^ >/dev/null 2>&1; then
+            git diff --name-only HEAD^ HEAD > changed_files.txt
+          else
+            git ls-files > changed_files.txt
+          fi
+
+          if grep -q '^src/' changed_files.txt; then
+            echo "src_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if grep -Eq '^(R/|NAMESPACE$|DESCRIPTION$)' changed_files.txt; then
+            echo "r_api_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "r_api_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if grep -q '^DESCRIPTION$' changed_files.txt; then
+            echo "description_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "description_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          version="$(awk -F': *' '$1 == "Version" { print $2 }' DESCRIPTION)"
+          echo "r_version=${version}" >> "$GITHUB_OUTPUT"
+
+          if [ -d src ]; then
+            src_hash="$(
+              git ls-files src \
+              | sort \
+              | xargs sha256sum \
+              | sha256sum \
+              | awk '{ print $1 }'
+            )"
+          else
+            src_hash="no-src-directory"
+          fi
+          echo "r_src_tree_hash=${src_hash}" >> "$GITHUB_OUTPUT"
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          files = [
+              line.strip()
+              for line in Path("changed_files.txt").read_text().splitlines()
+              if line.strip()
+          ]
+          Path("changed_files.json").write_text(json.dumps(files), encoding="utf-8")
+          PY
+
+      - name: Dispatch NNS-core sync
+        if: steps.detect.outputs.src_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.OVVO_SYNC_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          files_json="$(cat changed_files.json)"
+          gh api repos/OVVO-Financial/NNS-core/dispatches \
+            -f event_type=nns-r-src-updated \
+            -f client_payload[r_repo]="OVVO-Financial/NNS" \
+            -f client_payload[r_commit]="${GITHUB_SHA}" \
+            -f client_payload[r_ref]="${GITHUB_REF_NAME}" \
+            -f client_payload[r_version]="${{ steps.detect.outputs.r_version }}" \
+            -f client_payload[r_src_tree_hash]="${{ steps.detect.outputs.r_src_tree_hash }}" \
+            -f client_payload[src_changed]="${{ steps.detect.outputs.src_changed }}" \
+            -f client_payload[r_api_changed]="${{ steps.detect.outputs.r_api_changed }}" \
+            -f client_payload[description_changed]="${{ steps.detect.outputs.description_changed }}" \
+            -f client_payload[changed_files]="${files_json}"
+
+      - name: Dispatch NNS-python API or version review
+        if: steps.detect.outputs.r_api_changed == 'true' || steps.detect.outputs.description_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.OVVO_SYNC_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          files_json="$(cat changed_files.json)"
+          gh api repos/OVVO-Financial/NNS-python/dispatches \
+            -f event_type=nns-r-api-or-version-updated \
+            -f client_payload[r_repo]="OVVO-Financial/NNS" \
+            -f client_payload[r_commit]="${GITHUB_SHA}" \
+            -f client_payload[r_ref]="${GITHUB_REF_NAME}" \
+            -f client_payload[r_version]="${{ steps.detect.outputs.r_version }}" \
+            -f client_payload[r_src_tree_hash]="${{ steps.detect.outputs.r_src_tree_hash }}" \
+            -f client_payload[src_changed]="${{ steps.detect.outputs.src_changed }}" \
+            -f client_payload[r_api_changed]="${{ steps.detect.outputs.r_api_changed }}" \
+            -f client_payload[description_changed]="${{ steps.detect.outputs.description_changed }}" \
+            -f client_payload[changed_files]="${files_json}"

--- a/.github/workflows/downstream-sync-dispatch.yml
+++ b/.github/workflows/downstream-sync-dispatch.yml
@@ -2,7 +2,7 @@ name: Downstream sync dispatch
 
 on:
   push:
-    branches: [main]
+    branches: [NNS-Beta-Version]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### Motivation
- The existing workflow could miss source changes in a multi-commit push because it only diffed `HEAD^..HEAD`, so earlier commits in the pushed range were not inspected (PR #28 flagged this). 
- Make detection reliable for `push` events by using the full event range when available while preserving fallbacks for `workflow_dispatch` or shallow histories.

### Description
- Add `.github/workflows/downstream-sync-dispatch.yml` and configure the checkout with `fetch-depth: 0` so the push base commit is available for range diffs. 
- For push events use `git diff --name-only "${{ github.event.before }}" "${{ github.sha }}"` to gather `changed_files.txt`, with fallbacks to `git diff --name-only HEAD^ HEAD` and `git ls-files` when needed. 
- Emit detection outputs `src_changed`, `r_api_changed`, `description_changed`, `r_version`, and `r_src_tree_hash`, and write a `changed_files.json` payload. 
- Dispatch conditional downstream repository dispatches for `NNS-core` and `NNS-python` based on the detected flags.

### Testing
- Ran `git diff --check` which completed without reporting issues. 
- Ran `git diff --cached --check` which completed without reporting issues. 
- Attempted to run `actionlint .github/workflows/downstream-sync-dispatch.yml` but `actionlint` was not available in the environment so it was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2cd680e008832da59c7947677cdc66)