### PR TITLE
Use seasonal.factor values when weighting numeric ARMA lags

### DIFF
--- a/R/ARMA.R
+++ b/R/ARMA.R
@@ -107,7 +107,7 @@ NNS.ARMA <- function(variable,
     lag <- seasonal.factor
     output <- numeric(length(seasonal.factor))
     for(i in 1 : length(seasonal.factor)){
-      rev.var <- variable[seq(length(variable), 1, -i)]
+      rev.var <- variable[seq(length(variable), 1, -seasonal.factor[i])]
       output[i] <- abs(sd(rev.var) / mean(rev.var))
     }
     


### PR DESCRIPTION
This PR changes one line in `NNS.ARMA()`.

In the numeric `seasonal.factor` branch, the current code uses the index `i` as the step:

```r
rev.var <- variable[seq(length(variable), 1, -i)]
```

So if a user passes:

```r
seasonal.factor = c(12, 24, 36)
```

the weighting calculation uses steps:

```r
1, 2, 3
```

From my reading of the docs, `seasonal.factor` seems to represent actual lag values. So I think the weighting calculation should use:

```r
12, 24, 36
```

So I've changed the line to:

```r
rev.var <- variable[seq(length(variable), 1, -seasonal.factor[i])]
```

If the current index-based behavior is intentional, feel free to close this. I may be misunderstanding the intended weighting logic but from looking around in the ARMA pdf and other docs I think we should be passing the actual values in?