### PR TITLE
Optimize NNS.ARMA forecasting with pre-allocated buffer

### DIFF
--- a/R/ARMA.R
+++ b/R/ARMA.R
@@ -182,12 +182,21 @@ NNS.ARMA <- function(variable,
     variable <- c(variable, Estimates)
     FV <- variable
   } else {
-    
+
+    # Pre-allocate a single buffer holding the original series plus room for
+    # all h forecasts.  Each recursive step writes its estimate by index and
+    # passes the active length to generate.vectors, avoiding the O(N^2) growth
+    # of repeatedly re-allocating/copying via c(variable, Estimates[j]).
+    base.len <- length(variable)
+    variable.buf <- c(variable, numeric(h))
+
     # Regression for each estimate in h
     for (j in 1:h) {
+      cur.len <- base.len + (j - 1)
+
       # Regenerate seasonal.factor if dynamic
       if (dynamic) {
-        seas.matrix <- NNS.seas(variable, plot = FALSE)
+        seas.matrix <- NNS.seas(variable.buf[seq_len(cur.len)], plot = FALSE)
         if (!is.list(seas.matrix)) {
           M <- t(1)
         } else {
@@ -208,7 +217,7 @@ NNS.ARMA <- function(variable,
       }
       
       # Re-Generate vectors for 1:lag if dynamic
-      GV <- generate.vectors(variable, lag)
+      GV <- generate.vectors(variable.buf, lag, cur.len)
       Component.index <- GV$Component.index
       Component.series <- GV$Component.series
       
@@ -263,10 +272,12 @@ NNS.ARMA <- function(variable,
       if (method == "lin") Estimates[j] <- sum(Lin.estimates * Weights)
       if (method == 'both') Estimates[j] <- mean(c(Lin.estimates, Nonlin.estimates))
       if (method == "nonlin")  Estimates[j] <- sum(Nonlin.estimates * Weights)
-      
-      variable <- c(variable, Estimates[j])
-      FV <- variable
+
+      variable.buf[cur.len + 1] <- Estimates[j]
     } # j loop
+
+    variable <- variable.buf
+    FV <- variable
   }
   
   if(!is.null(pred.int)){

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -93,8 +93,8 @@ factor_2_dummy_FR <- function(x) {
     .Call(`_NNS_factor_2_dummy_FR`, x)
 }
 
-generate.vectors <- function(x, l) {
-    .Call(`_NNS_generate_vectors`, x, l)
+generate.vectors <- function(x, l, len = -1L) {
+    .Call(`_NNS_generate_vectors`, x, l, len)
 }
 
 generate.lin.vectors <- function(x, l, h = 1L) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -319,14 +319,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // generate_vectors
-List generate_vectors(NumericVector x, IntegerVector l);
-RcppExport SEXP _NNS_generate_vectors(SEXP xSEXP, SEXP lSEXP) {
+List generate_vectors(NumericVector x, IntegerVector l, int len);
+RcppExport SEXP _NNS_generate_vectors(SEXP xSEXP, SEXP lSEXP, SEXP lenSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericVector >::type x(xSEXP);
     Rcpp::traits::input_parameter< IntegerVector >::type l(lSEXP);
-    rcpp_result_gen = Rcpp::wrap(generate_vectors(x, l));
+    Rcpp::traits::input_parameter< int >::type len(lenSEXP);
+    rcpp_result_gen = Rcpp::wrap(generate_vectors(x, l, len));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -696,7 +697,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_NNS_is_discrete", (DL_FUNC) &_NNS_is_discrete, 1},
     {"_NNS_factor_2_dummy", (DL_FUNC) &_NNS_factor_2_dummy, 1},
     {"_NNS_factor_2_dummy_FR", (DL_FUNC) &_NNS_factor_2_dummy_FR, 1},
-    {"_NNS_generate_vectors", (DL_FUNC) &_NNS_generate_vectors, 2},
+    {"_NNS_generate_vectors", (DL_FUNC) &_NNS_generate_vectors, 3},
     {"_NNS_generate_lin_vectors", (DL_FUNC) &_NNS_generate_lin_vectors, 3},
     {"_NNS_ARMA_seas_weighting", (DL_FUNC) &_NNS_ARMA_seas_weighting, 2},
     {"_NNS_NNS_meboot_part", (DL_FUNC) &_NNS_NNS_meboot_part, 7},

--- a/src/internal_functions.cpp
+++ b/src/internal_functions.cpp
@@ -176,8 +176,13 @@ SEXP factor_2_dummy_FR(SEXP x) {
 
 // ---------- 4) generate.vectors ----------
 // [[Rcpp::export(name = "generate.vectors")]]
-List generate_vectors(NumericVector x, IntegerVector l) {
-  int n = x.size();
+List generate_vectors(NumericVector x, IntegerVector l, int len = -1) {
+  // 'len' lets the caller treat only the first 'len' elements of 'x' as the
+  // active series, so a persistent pre-allocated buffer can be reused across
+  // recursive forecast steps without re-allocating or copying a growing
+  // vector each step.  len < 0 (default) preserves the original behaviour of
+  // using the full length of 'x'.
+  int n = (len < 0) ? x.size() : len;
   List comp_series(l.size()), comp_index(l.size());
   for (int t = 0; t < l.size(); ++t) {
     int lag = l[t];


### PR DESCRIPTION
## Summary
This PR optimizes the NNS.ARMA forecasting function by eliminating repeated vector allocations and copies during recursive forecast steps. Instead of growing the variable vector with `c(variable, Estimates[j])` in each iteration (O(N²) complexity), the implementation now uses a pre-allocated buffer that is reused across all forecast steps.

## Key Changes
- **Pre-allocated buffer**: Replaced dynamic vector growth with a single pre-allocated buffer (`variable.buf`) that holds the original series plus space for all h forecasts
- **Updated generate.vectors()**: Added an optional `len` parameter to the C++ function to allow treating only the first `len` elements of a vector as the active series, avoiding unnecessary copying
- **Simplified loop logic**: Each recursive step now writes its estimate directly to the buffer by index and passes the current active length to helper functions
- **Updated R/Rcpp bindings**: Modified function signatures in RcppExports.R and RcppExports.cpp to support the new `len` parameter

## Implementation Details
- The `len` parameter in `generate_vectors()` defaults to -1, preserving backward compatibility by using the full vector length when not specified
- The buffer approach maintains the same algorithmic behavior while significantly reducing memory allocation overhead
- Seasonal factor regeneration and vector generation now operate on the appropriate slice of the pre-allocated buffer using `variable.buf[seq_len(cur.len)]` and the `cur.len` parameter

https://claude.ai/code/session_017LoDvrwhweogYBZVUGtWNe