### PR TITLE
Optimize NNS.reg for multivariate callers with early return

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tests/testthat/*.pdf
 NNS.Rproj
 src/*.o
 src/*.dll
+src/*.so
+Rplots.pdf

--- a/R/Regression.R
+++ b/R/Regression.R
@@ -710,9 +710,15 @@ NNS.reg = function (x, y,
   regression.points$y <- pmin(pmax(regression.points$y, min(y)), max(y))
   
   if(!is.null(type) && type=="class") regression.points$y <- pmax(min(y), pmin(max(y), ifelse(regression.points$y %% 1 < 0.5, floor(regression.points$y), ceiling(regression.points$y))))
-  
-  
-  # Coefficients 
+
+  # Multivariate callers (e.g. NNS.ARMA, NNS.stack, NNS.boost) only consume the
+  # consolidated regression points.  regression.points is final at this stage;
+  # the downstream Regression.Coefficients / fitted-value computation below does
+  # not mutate it, so return early to skip that wasted work on every call.
+  if (multivariate.call) return(regression.points[, .(x, y)])
+
+
+  # Coefficients
   Regression.Coefficients <- regression.points[, .(rise, run)]
   Regression.Coefficients <- Regression.Coefficients[complete.cases(Regression.Coefficients), ]
   upper.x <- regression.points[(2:.N), x]


### PR DESCRIPTION
## Summary
This PR optimizes the `NNS.reg` function by adding an early return path for multivariate callers (such as NNS.ARMA, NNS.stack, and NNS.boost) to avoid unnecessary downstream computation.

## Key Changes
- **Early return for multivariate calls**: Added a conditional check that returns consolidated regression points immediately when `multivariate.call` is TRUE, skipping the coefficient calculation and fitted-value computation that these callers don't need
- **Performance improvement**: Eliminates redundant `Regression.Coefficients` computation and related operations for every multivariate caller invocation
- **Code clarity**: Added explanatory comments documenting why the early return is safe and beneficial
- **Gitignore updates**: Added `src/*.so` and `Rplots.pdf` to ignore compiled shared objects and plot output files

## Implementation Details
The optimization recognizes that multivariate callers only consume the consolidated regression points (x and y coordinates) and don't use the coefficient calculations. By returning early at line 718, we skip the entire downstream coefficient computation block that would otherwise execute unnecessarily on every call from these multivariate functions.

https://claude.ai/code/session_01Xzh6Mq6zraPFFv3z43MXTf