### PR TITLE
Complete infinity handling in NNS_reg_points_cpp + fix .NNS.reg.part.xonly roxygen placement

### DIFF
--- a/R/Regression.R
+++ b/R/Regression.R
@@ -130,24 +130,6 @@
 #' @export
 
 
-# Lean XONLY partition for the native NNS.reg fast path: calls NNS_part_cpp
-# directly and returns the regression points as plain vectors, skipping the
-# data.table construction / setorder / coercion done by NNS.part().  Ordering
-# by quadrant uses radix (C locale), matching data.table::setorder; discrete-x
-# rounding mirrors NNS.part().  Bit-identical to NNS.part(...)$regression.points.
-.NNS.reg.part.xonly <- function(x, y, ord) {
-  out <- NNS_part_cpp(x = x, y = y, type = "XONLY",
-                      order_in = as.integer(ord), obs_req = 0L,
-                      min_obs_stop = TRUE, noise_reduction = "off")
-  rp <- out[["regression.points"]]
-  o  <- base::order(rp$quadrant, method = "radix")
-  rpx <- rp$x[o]
-  rpy <- rp$y[o]
-  if (is.discrete(x)) rpx <- ifelse(rpx %% 1 < 0.5, floor(rpx), ceiling(rpx))
-  list(x = rpx, y = rpy, dt_quadrant = out$dt$quadrant)
-}
-
-
 NNS.reg = function (x, y,
                     factor.2.dummy = TRUE, order = NULL,
                     dim.red.method = NULL, tau = NULL,
@@ -1043,4 +1025,26 @@ NNS.reg = function (x, y,
                    "Fitted.xy" = fitted))
   }
   
+}
+
+# Lean XONLY partition for the native NNS.reg fast path: calls NNS_part_cpp
+# directly and returns the regression points as plain vectors, skipping the
+# data.table construction / setorder / coercion done by NNS.part().  Ordering
+# by quadrant uses radix (C locale), matching data.table::setorder; discrete-x
+# rounding mirrors NNS.part() (round finite values only, preserving infinities).
+# Bit-identical to NNS.part(...)$regression.points.  Defined after NNS.reg (not
+# between its roxygen block and definition) so the docs stay attached to NNS.reg.
+.NNS.reg.part.xonly <- function(x, y, ord) {
+  out <- NNS_part_cpp(x = x, y = y, type = "XONLY",
+                      order_in = as.integer(ord), obs_req = 0L,
+                      min_obs_stop = TRUE, noise_reduction = "off")
+  rp <- out[["regression.points"]]
+  o  <- base::order(rp$quadrant, method = "radix")
+  rpx <- rp$x[o]
+  rpy <- rp$y[o]
+  if (is.discrete(x)) {
+    finite <- is.finite(rpx)
+    rpx[finite] <- ifelse(rpx[finite] %% 1 < 0.5, floor(rpx[finite]), ceiling(rpx[finite]))
+  }
+  list(x = rpx, y = rpy, dt_quadrant = out$dt$quadrant)
 }

--- a/src/nns_reg_points.cpp
+++ b/src/nns_reg_points.cpp
@@ -143,8 +143,9 @@ DataFrame NNS_reg_points_cpp(NumericVector x_, NumericVector y_,
   std::vector<double> bx = rx, by = ry;
   bx.push_back(central_x); by.push_back(central_y);
   std::vector<double> fx, fy;
+  // complete.cases() keeps Inf/-Inf and drops only NA/NaN (ISNAN covers both).
   for (size_t i = 0; i < bx.size(); ++i)
-    if (R_finite(bx[i]) && R_finite(by[i])) { fx.push_back(bx[i]); fy.push_back(by[i]); }
+    if (!ISNAN(bx[i]) && !ISNAN(by[i])) { fx.push_back(bx[i]); fy.push_back(by[i]); }
   std::vector<double> cx2, cy2;
   consolidate(fx, fy, cx2, cy2);
 
@@ -156,12 +157,13 @@ DataFrame NNS_reg_points_cpp(NumericVector x_, NumericVector y_,
 
   std::vector<double> y_min, y_midmin, x_midmin;
   std::vector<double> y_max, y_midmax, x_midmax;
+  // na.omit() (like complete.cases) keeps Inf/-Inf and drops only NA/NaN.
   for (size_t i = 0; i < x.size(); ++i) {
     const double xi = x[i], yi = y[i];
-    if (xi <= minr   && R_finite(yi)) y_min.push_back(yi);
-    if (xi <= mid_min) { if (R_finite(yi)) y_midmin.push_back(yi); if (R_finite(xi)) x_midmin.push_back(xi); }
-    if (xi >= maxr   && R_finite(yi)) y_max.push_back(yi);
-    if (xi >= mid_max) { if (R_finite(yi)) y_midmax.push_back(yi); if (R_finite(xi)) x_midmax.push_back(xi); }
+    if (xi <= minr   && !ISNAN(yi)) y_min.push_back(yi);
+    if (xi <= mid_min) { if (!ISNAN(yi)) y_midmin.push_back(yi); if (!ISNAN(xi)) x_midmin.push_back(xi); }
+    if (xi >= maxr   && !ISNAN(yi)) y_max.push_back(yi);
+    if (xi >= mid_max) { if (!ISNAN(yi)) y_midmax.push_back(yi); if (!ISNAN(xi)) x_midmax.push_back(xi); }
   }
   const int l_y_min  = (int) y_min.size();
   const int l_y_midmin = (int) y_midmin.size();
@@ -238,8 +240,9 @@ DataFrame NNS_reg_points_cpp(NumericVector x_, NumericVector y_,
   ex.push_back(maxx);      ey.push_back(max_rps_y);      // max.rps
   ex.push_back(central_x); ey.push_back(central_y);      // med.rps
   std::vector<double> gx, gy;
+  // complete.cases() keeps Inf/-Inf and drops only NA/NaN.
   for (size_t i = 0; i < ex.size(); ++i)
-    if (R_finite(ex[i]) && R_finite(ey[i])) { gx.push_back(ex[i]); gy.push_back(ey[i]); }
+    if (!ISNAN(ex[i]) && !ISNAN(ey[i])) { gx.push_back(ex[i]); gy.push_back(ey[i]); }
   std::vector<double> hx, hy;
   consolidate(gx, gy, hx, hy);
 


### PR DESCRIPTION
## Summary

Follow-up to the P2 infinity fix in #35. #35 made `NNS.part` / `NNS_part.cpp` preserve infinities in their complete-case handling, but the native regression-point builder `NNS_reg_points_cpp` was left untouched — so `NNS.reg`'s native fast path still diverged from the pure-R path on non-missing `Inf`/`-Inf` inputs (~7/500 in a randomized check). This also fixes a roxygen placement bug that #35 didn't address.

## Changes

**1. `src/nns_reg_points.cpp` — finish the preserve-infinities fix**
The complete-case steps (Step C, Step E) and the endpoint subsets (`y.min`/`y.mid.min`/`y.max`/`y.mid.max` and the `x.mid.*` unique counts) filtered with `R_finite()`, which drops infinities. R's `complete.cases()` / `na.omit()` keep `Inf`/`-Inf` and drop only `NA`/`NaN`. Switched those filters to `!ISNAN()`, matching R and consistent with #35's direction. The gravity-input filters stay `R_finite()` because `gravity()` itself drops infinities.

**2. `R/Regression.R` — roxygen placement (still broken on base)**
`.NNS.reg.part.xonly` had been inserted between `NNS.reg`'s roxygen block (`#' @export`) and the `NNS.reg` definition, so roxygen attached `NNS.reg`'s documentation to the helper (`devtools::document()` would write `NNS.reg.part.xonly.Rd` and **delete `NNS.reg.Rd`**, dropping `NNS.reg` from the generated docs/NAMESPACE). Moved the helper below `NNS.reg`. Its discrete-x rounding now rounds finite values only (preserving infinities), matching #35's `Partition_Map.R` (`RP[is.finite(x), x := ...]`).

Net diff is two files; #35's `NNS_part.cpp` / `Partition_Map.R` / `test_NNS_reg_infinite.R` are untouched.

## Verification

- **Infinities:** `Inf`/`-Inf` injected in `y`, in `x`, and in discrete `x` — native ON vs OFF identical **500/500 each** (previously diverged).
- **No regression:** 1500 finite randomized inputs — native ON vs OFF bit-identical (worst abs diff `0e+00`).
- **Docs:** `roxygen2::roxygenise()` writes `man/NNS.reg.Rd` (not deleted), no `NNS.reg.part.xonly.Rd`, `export(NNS.reg)` intact.
- **Tests:** `testthat` **132 passed / 0 failed** with `NNS.native` ON and OFF (includes #35's infinity test).

https://claude.ai/code/session_01Xzh6Mq6zraPFFv3z43MXTf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xzh6Mq6zraPFFv3z43MXTf)_