### PR TITLE
Fix NNS.norm unequal-length list detection and variable assignment

### DIFF
--- a/R/Normalization.R
+++ b/R/Normalization.R
@@ -39,23 +39,23 @@ NNS.norm <- function(X,
   if(any(class(X)%in%c("tbl","data.table"))) X <- as.data.frame(X)
 
   if(any(class(X)%in%"list")){
-    if(sum(diff(sapply(X, length))) != 0) linear <- TRUE
+    if(length(unique(sapply(X, length))) > 1) linear <- TRUE
     m <- sapply(X, mean)
-  } else { 
+  } else {
     X <- apply(X, 2, unlist)
     m <- colMeans(X)
   }
-  
-  
+
+
   m[m==0] <- 1e-10
   RG <- m %o% (1 / m)
-  
+
   if(!linear){
-    if(any(class(X)%in%"list")) do.call(cbind, X) else (X)
+    if(any(class(X)%in%"list")) X_mat <- do.call(cbind, X) else X_mat <- X
     if(length(m) < 10){
-      scale.factor <- abs(cor(X))
+      scale.factor <- abs(cor(X_mat))
     } else {
-      scale.factor <- abs(NNS.dep(X)$Dependence)
+      scale.factor <- abs(NNS.dep(X_mat)$Dependence)
     }
     scales <- colMeans(RG * scale.factor)
   } else {
@@ -90,7 +90,8 @@ NNS.norm <- function(X,
   if(any(class(X_Normalized)%in%"list")){
     names(X_Normalized) <- paste0(names(X), " Normalized")
   } else {
-    labels <- c(colnames(X), paste0(colnames(X), " Normalized"))
+    base.names <- if(any(class(X)%in%"list")) names(X) else colnames(X)
+    labels <- c(base.names, paste0(base.names, " Normalized"))
     colnames(X_Normalized) <- labels[(n + 1) : (2 * n)]
     rows <- rownames(X_Normalized)
   }

--- a/tests/testthat/test_Normalization.R
+++ b/tests/testthat/test_Normalization.R
@@ -1,0 +1,55 @@
+# Values
+x <- c(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
+y <- c(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0)
+z <- c(0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1)
+A <- cbind(x, y, z)
+
+test_that(
+  "NNS.norm - linear matrix path equalizes means", {
+    N <- NNS.norm(A, linear = TRUE)
+    expect_equal(dim(N), dim(A))
+    expect_equal(as.numeric(colMeans(N)), rep(mean(colMeans(A)), 3), tolerance = 1e-12)
+  }
+)
+
+test_that(
+  "NNS.norm - nonlinear matrix path returns finite matrix", {
+    N <- NNS.norm(A)
+    expect_equal(dim(N), dim(A))
+    expect_true(all(is.finite(N)))
+  }
+)
+
+test_that(
+  "NNS.norm - equal-length list matches matrix path with linear = FALSE", {
+    N_matrix <- NNS.norm(A)
+    N_list <- NNS.norm(list(x, y, z))
+    expect_equal(unname(N_list), unname(N_matrix), tolerance = 1e-12)
+  }
+)
+
+test_that(
+  "NNS.norm - unequal-length list forces linear scaling", {
+    vec1 <- c(1, 2, 3, 4, 5, 6, 7)
+    vec2 <- c(10, 20, 30, 40, 50, 60)
+    vec3 <- c(0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3)
+    N <- NNS.norm(list(vec1, vec2, vec3))
+    expect_true(is.list(N))
+    expect_equal(lengths(N, use.names = FALSE), c(7L, 6L, 9L))
+    m <- c(mean(vec1), mean(vec2), mean(vec3))
+    expect_equal(unname(sapply(N, mean)), rep(mean(m), 3), tolerance = 1e-12)
+  }
+)
+
+test_that(
+  "NNS.norm - zero-sum length diffs still detected as unequal", {
+    vec1 <- c(1, 2, 3, 4, 5)
+    vec2 <- c(10, 20, 30, 40, 50, 60)
+    vec3 <- c(0.5, 0.6, 0.7, 0.8, 0.9)
+    N <- NNS.norm(list(vec1, vec2, vec3))
+    expect_true(is.list(N))
+    expect_equal(lengths(N, use.names = FALSE), c(5L, 6L, 5L))
+    m <- c(mean(vec1), mean(vec2), mean(vec3))
+    expect_equal(unname(sapply(N, mean)), rep(mean(m), 3), tolerance = 1e-12)
+  }
+)


### PR DESCRIPTION
## Summary
This PR fixes bugs in the `NNS.norm` function related to detecting unequal-length lists and properly assigning variables in the nonlinear normalization path. It also adds comprehensive test coverage for the normalization function.

## Key Changes

- **Fixed unequal-length list detection**: Changed from `sum(diff(sapply(X, length))) != 0` to `length(unique(sapply(X, length))) > 1` to correctly identify when list elements have different lengths. The original approach could miss cases where length differences sum to zero (e.g., +1, -1).

- **Fixed variable assignment in nonlinear path**: Added explicit assignment of `X_mat` when converting list input to matrix form. Previously, the result of `do.call(cbind, X)` or `X` was not being assigned, causing subsequent `cor()` and `NNS.dep()` calls to operate on the wrong data.

- **Improved column name handling**: Updated the logic for extracting base column names to handle both list and matrix inputs correctly, using `names(X)` for lists and `colnames(X)` for matrices.

- **Code cleanup**: Fixed trailing whitespace and formatting inconsistencies.

## Test Coverage
Added comprehensive test suite (`test_Normalization.R`) covering:
- Linear normalization with mean equalization
- Nonlinear normalization returning finite values
- Equal-length list equivalence to matrix input
- Unequal-length list handling with linear scaling
- Edge case: zero-sum length differences still detected as unequal

https://claude.ai/code/session_01JMQ9tSZyAMwerv7BdY6E5w