### PR TITLE
Scale NNS.M.reg default n.best by sqrt(observations), fixing order=NULL ≡ order="max" collapse

### DIFF
--- a/R/Multivariate_Regression.R
+++ b/R/Multivariate_Regression.R
@@ -126,7 +126,7 @@ NNS.M.reg <- function (X_n, Y, factor.2.dummy = TRUE, order = NULL, n.best = NUL
   
   if(is.null(n.best)){
     dependence <- NNS.copula(cbind(original.IVs, original.DV))
-    n.best <- max(1, floor((1-dependence)*sqrt(n)))
+    n.best <- max(1, floor((1-dependence)*sqrt(nrow(original.IVs))))
   }
   
   ### Clamp n.best to available RPM rows.


### PR DESCRIPTION
## Problem

On continuous multivariate data, `NNS.reg(..., order = NULL)` produced point estimates **identical** to `order = "max"` (pure 1-NN), defeating the dependence-driven smoothing that `order = NULL` is supposed to provide. Reproduced on 5-feature uniform data: `identical(p_null, p_max)` was `TRUE`.

## Root cause

Two compounding facts:

1. On continuous predictors, the per-dimension interval crossing places nearly every observation in its own cell for any resolved order ≳ 3, so fitted values equal the raw responses and all smoothing must come from `n.best`.
2. In `NNS.M.reg`, the default `n.best <- max(1, floor((1-dependence)*sqrt(n)))` uses `n`, which line 11 reassigns to `ncol(original.IVs)`. With `sqrt(#features) ≤ 2.24` for anything under 9 predictors, the default collapses to `n.best = 1` whenever dependence exceeds ~0.1 — a dead smoothing knob that forces 1-NN, i.e. exactly `order = "max"` behavior.

## Fix

Use `sqrt(nrow(original.IVs))` — the classic k ~ √N heuristic scaled by (1 − dependence), and consistent with the `sqrt(n_obs)` `n.best` grid that `NNS.stack` already cross-validates over.

## Verification (live, R 4.3.3 + this package built from source)

- `order = NULL` vs `order = "max"`: now **distinct** (max abs diff 2.539 on 200×5 test data; previously `identical = TRUE`).
- Integer orders unaffected: univariate regression point counts for order 1/2/4/max/NULL = 3/5/11/200/19 before and after; multivariate order=1/2 estimates unchanged.
- Cross-validated against the Python port (OVVO-Financial/NNS-python) on shared CSV data: post-fix predictions agree bit-exactly on 59/60 rows (the remaining row is the out-of-support gradient-extension path, diff 3.4e-3).
- Benchmark effect (5 seeds × 3 regimes, n_train=500): default `NNS.reg` RMSE improves iid 1.39→1.12, support_shift 2.22→2.07, prior_trap 1.58→1.25.
- `NNS.stack`/`NNS.boost` are unaffected by this default (they always set `n.best` explicitly via CV / hardcoded values).

Companion Python-port PR: OVVO-Financial/NNS-python (same change in `_resolve_n_best`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPbZvtDw4h2XJo9w5hw57h

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPbZvtDw4h2XJo9w5hw57h)_