### PR TITLE
Fix out-of-support mask misalignment for multi-row point.est in NNS.M.reg

### DIFF
--- a/R/Multivariate_Regression.R
+++ b/R/Multivariate_Regression.R
@@ -163,7 +163,11 @@ NNS.M.reg <- function (X_n, Y, factor.2.dummy = TRUE, order = NULL, n.best = NUL
     central.points <- apply(REGRESSION.POINT.MATRIX[, 1:n, drop = FALSE], 2, gravity)
     
     predict.fit <- numeric()
-    outsiders <- point.est < minimums | point.est > maximums
+    # Compare each column against its own bound: direct matrix < vector
+    # comparison recycles the length-n bounds down the rows (column-major),
+    # misaligning the mask whenever point.est has more than one row.
+    point.est_matrix <- as.matrix(point.est)
+    outsiders <- sweep(point.est_matrix, 2, minimums, "<") | sweep(point.est_matrix, 2, maximums, ">")
     outsiders[is.na(outsiders)] <- 0
     
     # Single point estimation


### PR DESCRIPTION
## Problem

`NNS.M.reg` flags out-of-support point estimates with:

```r
outsiders <- point.est < minimums | point.est > maximums
```

Direct matrix-vs-vector comparison recycles the length-n bounds **down the rows** (column-major), so for any `point.est` with more than one row, each row is compared against a rotated set of bounds instead of its own column's min/max. Consequences:

- True outsiders silently skip the boundary gradient extension (and in-support rows can receive it).
- Bulk predictions disagree with the same rows predicted one at a time: on 500×5 training data with 250 fully out-of-support test rows, batch-of-30 vs one-row-at-a-time agreed on only **6/30 rows** (diffs up to 0.84) — and the 24 disagreements were exactly the rows misclassified by the recycled mask.

The mask is only correct in the 1×n case, which is why single-point calls never exposed it.

## Fix

Compare each column against its own bound with `sweep()`:

```r
outsiders <- sweep(point.est_matrix, 2, minimums, "<") | sweep(point.est_matrix, 2, maximums, ">")
```

## Verification (live, R 4.3.3 + package built from this branch)

- Bulk vs single-row predictions now agree **30/30** on the previously failing batch.
- R output matches the Python port (OVVO-Financial/NNS-python, which already implements the correct per-column semantics via broadcasting) **bit-for-bit on 750/750 rows** across three regimes (iid, support-shift, prior-trap), max abs diff 1.1e-14.
- In-support predictions are unchanged (mask fix only affects which rows enter the outsider branch).

No Python-side change required — this brings R in line with the port and with R's own single-row behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPbZvtDw4h2XJo9w5hw57h

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPbZvtDw4h2XJo9w5hw57h)_