### PR TITLE
Native prediction kernel for the repaired regression engine (performance restored)

### DIFF
--- a/R/Boost.R
+++ b/R/Boost.R
@@ -142,6 +142,17 @@ NNS.boost <- function(IVs.train,
         x <- data.frame(x, check.names = FALSE)
         names(x) <- train_names
       } else if (length(x) == p) {
+        supplied <- names(x)
+        if (!is.null(supplied) && all(nzchar(supplied)) &&
+            !identical(make.unique(supplied, sep = "."), train_names)) {
+          # Align a named test row by the training predictor names rather
+          # than silently renaming positionally supplied values.
+          if (anyDuplicated(supplied) || !setequal(supplied, train_names)) {
+            stop("Named [IVs.test] values must exactly match the training predictors.",
+                 call. = FALSE)
+          }
+          x <- x[train_names]
+        }
         x <- as.data.frame(as.list(x), check.names = FALSE,
                            stringsAsFactors = FALSE)
         names(x) <- train_names

--- a/R/Multivariate_Regression.R
+++ b/R/Multivariate_Regression.R
@@ -102,20 +102,26 @@
     stop("[point.est] contains missing or nonfinite values.", call. = FALSE)
   }
   
-  worker <- function(i) .nns_mreg_predict_one(
+  # Native serial kernel implementing exactly .nns_mreg_predict_one:
+  # same metric dispatch, stable tie ordering, k = 1 tie aggregation, ensemble
+  # weights, and exact weighted class mode. No global thread state is touched.
+  rpm.x <- as.matrix(rpm[, setdiff(names(rpm), "y.hat"), drop = FALSE])
+  storage.mode(rpm.x) <- "double"
+  storage.mode(Xtest) <- "double"
+  dist.code <- match(dist, c("L2", "L1", "FACTOR")) - 1L
+  as.numeric(NNS_mreg_predict_cpp(
+    rpm.x, as.numeric(rpm$y.hat), Xtest, as.integer(k), dist.code,
+    as.numeric(minimums), as.numeric(maximums), isTRUE(is.class)
+  ))
+}
+
+# Reference pure-R implementation of the prediction rule, retained for
+# equivalence tests against NNS_mreg_predict_cpp.
+.nns_mreg_predict_reference <- function(Xtest, rpm, k, dist,
+                                        minimums, maximums, is.class) {
+  vapply(seq_len(nrow(Xtest)), function(i) .nns_mreg_predict_one(
     Xtest[i, ], rpm, k, dist, minimums, maximums, is.class
-  )
-  
-  # Use process-local parallelism only where fork is available. No global
-  # RcppParallel setting is mutated. Windows and single-core calls remain
-  # deterministic and sequential.
-  if (ncores > 1L && .Platform$OS.type != "windows" && nrow(Xtest) > 1L) {
-    unlist(parallel::mclapply(seq_len(nrow(Xtest)), worker,
-                              mc.cores = ncores, mc.preschedule = TRUE),
-           use.names = FALSE)
-  } else {
-    vapply(seq_len(nrow(Xtest)), worker, numeric(1L))
-  }
+  ), numeric(1L))
 }
 
 .nns_mreg_group_reduce <- function(z, noise.reduction, is.class) {
@@ -123,6 +129,17 @@
 }
 
 .nns_mreg_build_rpm <- function(X, y, ids, noise.reduction, is.class) {
+  # Fast path: every observation in its own cell (the common continuous case).
+  # Each reducer returns a singleton's own value, so the RPM is the data
+  # itself, ordered by interval ID exactly as split() would order the groups.
+  if (!anyDuplicated(ids)) {
+    o <- order(ids)
+    rpm <- as.data.frame(X[o, , drop = FALSE], stringsAsFactors = FALSE)
+    rpm$y.hat <- y[o]
+    names(rpm) <- c(colnames(X), "y.hat")
+    rownames(rpm) <- NULL
+    return(rpm)
+  }
   groups <- split(seq_len(nrow(X)), ids)
   rows <- lapply(groups, function(idx) {
     c(vapply(seq_len(ncol(X)), function(j) {

--- a/R/Partition_Map.R
+++ b/R/Partition_Map.R
@@ -37,11 +37,18 @@ NNS.part <- function(x, y, Voronoi = FALSE, type = NULL,
   
   if (length(x) != length(y)) stop("[x] and [y] must have the same length.", call. = FALSE)
   if (length(x) < 1L) stop("[x] and [y] must not be empty.", call. = FALSE)
-  if (anyNA(x) || anyNA(y)) stop("[x] and [y] must not contain missing values.", call. = FALSE)
   x <- as.numeric(x)
   y <- as.numeric(y)
-  if (any(!is.finite(x)) || any(!is.finite(y))) {
-    stop("[x] and [y] must contain only finite values.", call. = FALSE)
+  # Complete-case handling: drop pairs with NA/NaN in either variable but
+  # keep infinities, matching the historical NNS.part contract.
+  complete <- !(is.na(x) | is.na(y))
+  if (!all(complete)) {
+    x <- x[complete]
+    y <- y[complete]
+  }
+  if (length(x) < 1L) {
+    stop("[x] and [y] must contain at least one complete (non-missing) pair.",
+         call. = FALSE)
   }
   
   Voronoi <- .nns_reg_scalar_logical(Voronoi, "Voronoi")

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -29,6 +29,14 @@ NNS_distance_path_single_parallel_cpp <- function(RPM, yhat, Xtest, k, is_class,
     .Call(`_NNS_NNS_distance_path_single_parallel_cpp`, RPM, yhat, Xtest, k, is_class, nthreads)
 }
 
+NNS_mreg_predict_path_cpp <- function(rpm_x, yhat, Xtest, kmax, dist_code, mins, maxs, is_class) {
+    .Call(`_NNS_NNS_mreg_predict_path_cpp`, rpm_x, yhat, Xtest, kmax, dist_code, mins, maxs, is_class)
+}
+
+NNS_mreg_predict_cpp <- function(rpm_x, yhat, Xtest, k, dist_code, mins, maxs, is_class) {
+    .Call(`_NNS_NNS_mreg_predict_cpp`, rpm_x, yhat, Xtest, k, dist_code, mins, maxs, is_class)
+}
+
 NNS_part_cpp <- function(x, y, type, order_in, obs_req, min_obs_stop, noise_reduction, quadrants_only = FALSE) {
     .Call(`_NNS_NNS_part_cpp`, x, y, type, order_in, obs_req, min_obs_stop, noise_reduction, quadrants_only)
 }

--- a/R/Stack.R
+++ b/R/Stack.R
@@ -158,6 +158,17 @@ NNS.stack <- function(IVs.train,
         x <- data.frame(x, check.names = FALSE)
         names(x) <- train_names
       } else if (length(x) == p) {
+        supplied <- names(x)
+        if (!is.null(supplied) && all(nzchar(supplied)) &&
+            !identical(make.unique(supplied, sep = "."), train_names)) {
+          # Align a named test row by the training predictor names rather
+          # than silently renaming positionally supplied values.
+          if (anyDuplicated(supplied) || !setequal(supplied, train_names)) {
+            stop("Named [IVs.test] values must exactly match the training predictors.",
+                 call. = FALSE)
+          }
+          x <- x[train_names]
+        }
         x <- as.data.frame(as.list(x), check.names = FALSE,
                            stringsAsFactors = FALSE)
         names(x) <- train_names

--- a/R/Stack.R
+++ b/R/Stack.R
@@ -949,8 +949,11 @@ NNS.stack <- function(IVs.train,
   }
   
   
-  # Reproduce the production NNS.M.reg multiple-point prediction path for every
-  # k, including its out-of-training-range gradient extrapolation.
+  # Score every k with exactly the estimator the final NNS.reg fit uses:
+  # NNS_mreg_predict_path_cpp implements the repaired multivariate prediction
+  # rule (range-normalized metric, stable ties, ensemble weights) for
+  # k = 1..kmax. The repaired NNS.M.reg no longer extrapolates outside the
+  # training support, so no gradient extension is applied here either.
   .production_multivariate_path <- function(rpm, Xtest, train_design) {
     Xtest <- as.data.frame(Xtest, check.names = FALSE)
     feature_names <- setdiff(names(rpm), "y.hat")
@@ -958,98 +961,26 @@ NNS.stack <- function(IVs.train,
     train_design <- as.data.frame(train_design, check.names = FALSE)
     train_design <- train_design[, feature_names, drop = FALSE]
     kmax <- nrow(rpm)
-    
-    path <- suppressWarnings(
-      NNS.distance.path.bulk(
-        rpm = rpm,
-        Xtest = Xtest,
-        kmax = kmax,
-        class = NULL,
-        ncores = ncores
-      )
+
+    rpm_x <- as.matrix(rpm[, feature_names, drop = FALSE])
+    storage.mode(rpm_x) <- "double"
+    test_matrix <- as.matrix(Xtest)
+    storage.mode(test_matrix) <- "double"
+    minimums <- vapply(train_design, min, numeric(1L))
+    maximums <- vapply(train_design, max, numeric(1L))
+    dist_code <- match(dist, c("L2", "L1", "FACTOR")) - 1L
+
+    path <- NNS_mreg_predict_path_cpp(
+      rpm_x, as.numeric(rpm$y.hat), test_matrix, as.integer(kmax),
+      dist_code, as.numeric(minimums), as.numeric(maximums), FALSE
     )
-    path <- as.matrix(path)
-    if (nrow(path) != nrow(Xtest) && ncol(path) == nrow(Xtest)) path <- t(path)
-    if (nrow(path) != nrow(Xtest)) {
+    if (nrow(path) != nrow(test_matrix)) {
       stop("The production distance path returned an invalid row count.",
            call. = FALSE)
     }
-    
-    minimums <- vapply(train_design, min, numeric(1L))
-    maximums <- vapply(train_design, max, numeric(1L))
-    test_matrix <- as.matrix(Xtest)
-    outsiders <- sweep(test_matrix, 2L, minimums, "<") |
-      sweep(test_matrix, 2L, maximums, ">")
-    outsiders[is.na(outsiders)] <- FALSE
-    outsider_rows <- which(rowSums(outsiders) > 0L)
-    
-    if (length(outsider_rows)) {
-      rpm_features <- rpm[, feature_names, drop = FALSE]
-      central_points <- vapply(rpm_features, gravity, numeric(1L))
-      outside_points <- test_matrix[outsider_rows, , drop = FALSE]
-      boundary_points <- outside_points
-      for (j in seq_len(ncol(boundary_points))) {
-        boundary_points[, j] <- pmin(
-          pmax(boundary_points[, j], minimums[j]),
-          maximums[j]
-        )
-      }
-      
-      central_matrix <- matrix(
-        rep(central_points, each = nrow(boundary_points)),
-        nrow = nrow(boundary_points),
-        byrow = FALSE,
-        dimnames = list(NULL, feature_names)
-      )
-      mid_points <- (boundary_points + central_matrix) / 2
-      mid_points_2 <- (boundary_points + mid_points) / 2
-      
-      distance_1 <- sqrt(rowSums((boundary_points - central_matrix)^2))
-      distance_2 <- sqrt(rowSums((boundary_points - mid_points)^2))
-      distance_3 <- sqrt(rowSums((boundary_points - mid_points_2)^2))
-      
-      path_for <- function(points) {
-        points <- as.data.frame(points, check.names = FALSE)
-        names(points) <- feature_names
-        out <- suppressWarnings(
-          NNS.distance.path.bulk(
-            rpm = rpm,
-            Xtest = points,
-            kmax = kmax,
-            class = NULL,
-            ncores = ncores
-          )
-        )
-        out <- as.matrix(out)
-        if (nrow(out) != nrow(points) && ncol(out) == nrow(points)) out <- t(out)
-        out
-      }
-      
-      boundary_path <- path_for(boundary_points)
-      mid_path <- path_for(mid_points)
-      mid_2_path <- path_for(mid_points_2)
-      central_path <- path_for(matrix(central_points, nrow = 1L,
-                                      dimnames = list(NULL, feature_names)))
-      central_path <- matrix(rep(as.numeric(central_path),
-                                 each = length(outsider_rows)),
-                             nrow = length(outsider_rows),
-                             byrow = FALSE)
-      
-      d1 <- pmax(distance_1, 1e-10)
-      d2 <- pmax(distance_2, 1e-10)
-      d3 <- pmax(distance_3, 1e-10)
-      g1 <- sweep(boundary_path - central_path, 1L, d1, "/")
-      g2 <- sweep(boundary_path - mid_path, 1L, d2, "/")
-      g3 <- sweep(boundary_path - mid_2_path, 1L, d3, "/")
-      gradient <- (3 * g1 + 2 * g2 + g3) / 6
-      last_distance <- sqrt(rowSums((outside_points - boundary_points)^2))
-      path[outsider_rows, ] <- boundary_path +
-        sweep(gradient, 1L, last_distance, "*")
-    }
-    
     path
   }
-  
+
   .candidate_from_oof <- function(sum_matrix, count_matrix, candidate) {
     count <- count_matrix[, candidate]
     valid <- count > 0L

--- a/src/NNS_distance.cpp
+++ b/src/NNS_distance.cpp
@@ -213,14 +213,15 @@ SEXP NNS_distance_cpp(NumericMatrix X,
 namespace {
 inline double safe_eps() { return 1e-12; }
   
-  inline void compute_distances(const double* rpm, int n, int p,
-                                const double* test_row,
+  // R matrices are column-major: element (i, j) lives at i + j*nrow.
+  inline void compute_distances(const Rcpp::NumericMatrix& rpm,
+                                const Rcpp::NumericMatrix& xtest, int test_row,
                                 std::vector<double>& dist_out) {
+    const int n = rpm.nrow(), p = rpm.ncol();
     for (int i = 0; i < n; ++i) {
-      const double* xi = rpm + static_cast<std::size_t>(i) * p;
       double acc = 0.0;
       for (int j = 0; j < p; ++j) {
-        const double d = xi[j] - test_row[j];
+        const double d = rpm(i, j) - xtest(test_row, j);
         acc += d * d + std::fabs(d);
       }
       dist_out[i] = (acc == 0.0 ? safe_eps() : acc);
@@ -252,16 +253,13 @@ Rcpp::NumericMatrix NNS_distance_path_cpp(const Rcpp::NumericMatrix& RPM,
   if (kmax > n)                  kmax = n;
   
   Rcpp::NumericMatrix out(m, kmax);
-  const double* rpm_ptr  = REAL(RPM);
   const double* y_ptr    = REAL(yhat);
-  const double* tst_ptr  = REAL(Xtest);
   
   std::vector<double> dist(n), y_sorted(n), d_sorted(n);
   std::vector<int>    ord(n);
   
   for (int r = 0; r < m; ++r) {
-    const double* tr = tst_ptr + static_cast<std::size_t>(r) * p;
-    compute_distances(rpm_ptr, n, p, tr, dist);
+    compute_distances(RPM, Xtest, r, dist);
     argsort_by_distance(dist, ord);
     
     for (int i = 0; i < n; ++i) {
@@ -296,16 +294,13 @@ Rcpp::NumericVector NNS_distance_bulk_cpp(const Rcpp::NumericMatrix& RPM,
   if (k > n)                     k = n;
   
   Rcpp::NumericVector out(m);
-  const double* rpm_ptr  = REAL(RPM);
   const double* y_ptr    = REAL(yhat);
-  const double* tst_ptr  = REAL(Xtest);
   
   std::vector<double> dist(n);
   std::vector<int>    ord(n);
   
   for (int r = 0; r < m; ++r) {
-    const double* tr = tst_ptr + static_cast<std::size_t>(r) * p;
-    compute_distances(rpm_ptr, n, p, tr, dist);
+    compute_distances(RPM, Xtest, r, dist);
     argsort_by_distance(dist, ord);
     
     double csum_w = 0.0, csum_yw = 0.0;

--- a/src/NNS_mreg_predict.cpp
+++ b/src/NNS_mreg_predict.cpp
@@ -1,0 +1,380 @@
+// Native kernel for the repaired NNS.M.reg prediction rule.
+// Replicates R/Multivariate_Regression.R's .nns_mreg_predict_one exactly:
+//   - range-normalized L2 / L1 or Hamming (FACTOR) distances,
+//   - stable ascending ordering with index tie-break,
+//   - k = 1 aggregates all exact nearest-distance ties (gravity / class mode),
+//   - k > 1 uses the eight-component ensemble weights built from Rmath
+//     densities, matching the R helper term for term,
+//   - exact double-precision weighted class mode (max total, tie -> min value).
+// Serial by design: no global RcppParallel thread state is touched.
+#include <Rcpp.h>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+using namespace Rcpp;
+
+// central_tendencies.cpp
+double gravity_value(std::vector<double> x, bool discrete);
+
+namespace {
+
+// .nns_mreg_normalize_weights: nonfinite/negative -> 0; sum<=0 -> uniform.
+inline void normalize_weights(std::vector<double>& w) {
+  const std::size_t k = w.size();
+  double s = 0.0;
+  for (double& v : w) {
+    if (!R_finite(v) || v < 0.0) v = 0.0;
+    s += v;
+  }
+  if (s <= 0.0) {
+    for (double& v : w) v = 1.0 / static_cast<double>(k);
+  } else {
+    for (double& v : w) v /= s;
+  }
+}
+
+inline double sample_sd(const std::vector<double>& v) {
+  const std::size_t n = v.size();
+  if (n < 2) return NA_REAL;
+  double mu = 0.0;
+  for (double x : v) mu += x;
+  mu /= static_cast<double>(n);
+  double acc = 0.0;
+  for (double x : v) { const double d = x - mu; acc += d * d; }
+  return std::sqrt(acc / static_cast<double>(n - 1));
+}
+
+// .nns_mreg_weighted_mode: totals per distinct value, max total, tie -> min.
+inline double weighted_mode(const std::vector<double>& vals,
+                            const std::vector<double>& w) {
+  std::vector<std::pair<double, double> > items;
+  items.reserve(vals.size());
+  for (std::size_t i = 0; i < vals.size(); ++i) {
+    if (R_finite(vals[i]) && R_finite(w[i]) && w[i] >= 0.0) {
+      items.push_back(std::make_pair(vals[i], w[i]));
+    }
+  }
+  if (items.empty()) return NA_REAL;
+  std::sort(items.begin(), items.end());
+  double best_val = items[0].first;
+  double best_tot = -1.0;
+  std::size_t i = 0;
+  while (i < items.size()) {
+    const double v = items[i].first;
+    double tot = 0.0;
+    while (i < items.size() && items[i].first == v) { tot += items[i].second; ++i; }
+    if (tot > best_tot) { best_tot = tot; best_val = v; }
+  }
+  return best_val;
+}
+
+// .nns_mreg_ensemble_weights for the k selected (ascending) distances.
+inline std::vector<double> ensemble_weights(const std::vector<double>& d) {
+  const int k = static_cast<int>(d.size());
+  std::vector<double> total(k, 0.0);
+  const double kk = static_cast<double>(k);
+
+  std::vector<double> comp(k);
+
+  // uniform
+  for (int i = 0; i < k; ++i) total[i] += 1.0 / kk;
+
+  // student t density of distances, df = k
+  for (int i = 0; i < k; ++i) comp[i] = ::Rf_dt(d[i], kk, 0);
+  normalize_weights(comp);
+  for (int i = 0; i < k; ++i) total[i] += comp[i];
+
+  // inverse distance
+  for (int i = 0; i < k; ++i) comp[i] = 1.0 / std::max(d[i], 1e-12);
+  normalize_weights(comp);
+  for (int i = 0; i < k; ++i) total[i] += comp[i];
+
+  // exponential density of ranks, rate = 1/k (Rf_dexp takes the scale = k)
+  for (int i = 0; i < k; ++i) comp[i] = ::Rf_dexp(static_cast<double>(i + 1), kk, 0);
+  normalize_weights(comp);
+  for (int i = 0; i < k; ++i) total[i] += comp[i];
+
+  // reversed |log lognormal density| of ranks, sdlog = sample sd of ranks
+  {
+    std::vector<double> ranks(k);
+    for (int i = 0; i < k; ++i) ranks[i] = static_cast<double>(i + 1);
+    const double rank_sd = sample_sd(ranks);
+    if (R_finite(rank_sd) && rank_sd > 0.0) {
+      for (int i = 0; i < k; ++i)
+        comp[i] = std::fabs(::Rf_dlnorm(ranks[i], 0.0, rank_sd, 1));
+      normalize_weights(comp);
+      std::reverse(comp.begin(), comp.end());
+      for (int i = 0; i < k; ++i) total[i] += comp[i];
+    }
+  }
+
+  // power-law on ranks
+  for (int i = 0; i < k; ++i) {
+    const double r = static_cast<double>(i + 1);
+    comp[i] = 1.0 / (r * r);
+  }
+  normalize_weights(comp);
+  for (int i = 0; i < k; ++i) total[i] += comp[i];
+
+  // normal density of distances, sd = sample sd of distances
+  {
+    const double dist_sd = sample_sd(d);
+    if (R_finite(dist_sd) && dist_sd > 0.0) {
+      for (int i = 0; i < k; ++i) comp[i] = ::Rf_dnorm4(d[i], 0.0, dist_sd, 0);
+      normalize_weights(comp);
+      for (int i = 0; i < k; ++i) total[i] += comp[i];
+    }
+  }
+
+  // RBF on distances, bandwidth = 2 * sample variance
+  {
+    const double dist_sd = sample_sd(d);
+    const double dist_var = R_finite(dist_sd) ? dist_sd * dist_sd : NA_REAL;
+    if (R_finite(dist_var) && dist_var > 0.0) {
+      for (int i = 0; i < k; ++i) comp[i] = std::exp(-d[i] / (2.0 * dist_var));
+      normalize_weights(comp);
+      for (int i = 0; i < k; ++i) total[i] += comp[i];
+    }
+  }
+
+  normalize_weights(total);
+  return total;
+}
+
+}  // namespace
+
+namespace {
+
+inline void row_distances(const NumericMatrix& rpm_x, const NumericMatrix& Xtest,
+                          int r, int dist_code,
+                          const std::vector<int>& active,
+                          const std::vector<double>& inv_range,
+                          std::vector<double>& d) {
+  const int n = rpm_x.nrow(), p = rpm_x.ncol();
+  if (dist_code == 2) {
+    for (int i = 0; i < n; ++i) {
+      double mismatches = 0.0;
+      for (int j = 0; j < p; ++j)
+        if (rpm_x(i, j) != Xtest(r, j)) mismatches += 1.0;
+      d[i] = mismatches / static_cast<double>(p);
+    }
+  } else if (active.empty()) {
+    std::fill(d.begin(), d.end(), 0.0);
+  } else if (dist_code == 1) {
+    for (int i = 0; i < n; ++i) {
+      double acc = 0.0;
+      for (std::size_t a = 0; a < active.size(); ++a) {
+        const int j = active[a];
+        acc += std::fabs((rpm_x(i, j) - Xtest(r, j)) * inv_range[a]);
+      }
+      d[i] = acc;
+    }
+  } else {
+    for (int i = 0; i < n; ++i) {
+      double acc = 0.0;
+      for (std::size_t a = 0; a < active.size(); ++a) {
+        const int j = active[a];
+        const double z = (rpm_x(i, j) - Xtest(r, j)) * inv_range[a];
+        acc += z * z;
+      }
+      d[i] = std::sqrt(acc);
+    }
+  }
+}
+
+inline double aggregate_min_ties(const std::vector<double>& d,
+                                 const NumericVector& yhat,
+                                 bool is_class) {
+  const int n = static_cast<int>(d.size());
+  double dmin = d[0];
+  for (int i = 1; i < n; ++i) if (d[i] < dmin) dmin = d[i];
+  std::vector<double> tied;
+  for (int i = 0; i < n; ++i) if (d[i] == dmin) tied.push_back(yhat[i]);
+  if (is_class) {
+    std::vector<double> ones(tied.size(), 1.0);
+    return weighted_mode(tied, ones);
+  }
+  std::vector<double> finite_tied;
+  finite_tied.reserve(tied.size());
+  for (double v : tied) if (R_finite(v)) finite_tied.push_back(v);
+  return gravity_value(finite_tied, false);
+}
+
+inline void active_columns(const NumericVector& mins, const NumericVector& maxs,
+                           std::vector<int>& active, std::vector<double>& inv_range) {
+  const int p = mins.size();
+  for (int j = 0; j < p; ++j) {
+    const double range = maxs[j] - mins[j];
+    if (R_finite(range) && range > 0.0) {
+      active.push_back(j);
+      inv_range.push_back(1.0 / range);
+    }
+  }
+}
+
+}  // namespace
+
+// Prediction path for every k = 1..kmax under the same rule as
+// NNS_mreg_predict_cpp, so cross-validated n.best selection scores exactly
+// the estimator the final NNS.reg fit will use.
+// [[Rcpp::export]]
+NumericMatrix NNS_mreg_predict_path_cpp(const NumericMatrix& rpm_x,
+                                        const NumericVector& yhat,
+                                        const NumericMatrix& Xtest,
+                                        int kmax,
+                                        int dist_code,
+                                        const NumericVector& mins,
+                                        const NumericVector& maxs,
+                                        bool is_class) {
+  const int n = rpm_x.nrow(), p = rpm_x.ncol(), m = Xtest.nrow();
+  if (yhat.size() != n) stop("yhat length must equal nrow(rpm_x)");
+  if (Xtest.ncol() != p) stop("Xtest and rpm_x must have the same columns");
+  if (mins.size() != p || maxs.size() != p) stop("mins/maxs must have one value per column");
+  if (kmax < 1) stop("kmax must be >= 1");
+  if (kmax > n) kmax = n;
+
+  std::vector<int> active;
+  std::vector<double> inv_range;
+  active_columns(mins, maxs, active, inv_range);
+
+  NumericMatrix out(m, kmax);
+  std::vector<double> d(n);
+  std::vector<int> idx(n);
+
+  for (int r = 0; r < m; ++r) {
+    row_distances(rpm_x, Xtest, r, dist_code, active, inv_range, d);
+
+    for (int i = 0; i < n; ++i) idx[i] = i;
+    std::stable_sort(idx.begin(), idx.end(),
+                     [&d](int a, int b) { return d[a] < d[b]; });
+
+    std::vector<double> dk(kmax), yk(kmax);
+    for (int i = 0; i < kmax; ++i) {
+      dk[i] = d[idx[i]];
+      yk[i] = yhat[idx[i]];
+    }
+
+    out(r, 0) = aggregate_min_ties(d, yhat, is_class);
+    for (int k = 2; k <= kmax; ++k) {
+      const std::vector<double> dsub(dk.begin(), dk.begin() + k);
+      const std::vector<double> w = ensemble_weights(dsub);
+      if (is_class) {
+        const std::vector<double> ysub(yk.begin(), yk.begin() + k);
+        out(r, k - 1) = weighted_mode(ysub, w);
+      } else {
+        double dot = 0.0;
+        for (int i = 0; i < k; ++i) dot += yk[i] * w[i];
+        out(r, k - 1) = dot;
+      }
+    }
+  }
+  return out;
+}
+
+// dist_code: 0 = L2, 1 = L1, 2 = FACTOR (Hamming over encoded columns).
+// [[Rcpp::export]]
+NumericVector NNS_mreg_predict_cpp(const NumericMatrix& rpm_x,
+                                   const NumericVector& yhat,
+                                   const NumericMatrix& Xtest,
+                                   int k,
+                                   int dist_code,
+                                   const NumericVector& mins,
+                                   const NumericVector& maxs,
+                                   bool is_class) {
+  const int n = rpm_x.nrow(), p = rpm_x.ncol(), m = Xtest.nrow();
+  if (yhat.size() != n) stop("yhat length must equal nrow(rpm_x)");
+  if (Xtest.ncol() != p) stop("Xtest and rpm_x must have the same columns");
+  if (mins.size() != p || maxs.size() != p) stop("mins/maxs must have one value per column");
+  if (k < 1) stop("k must be >= 1");
+
+  // Active columns and reciprocal ranges for the normalized metrics.
+  std::vector<int> active;
+  std::vector<double> inv_range;
+  for (int j = 0; j < p; ++j) {
+    const double range = maxs[j] - mins[j];
+    if (R_finite(range) && range > 0.0) {
+      active.push_back(j);
+      inv_range.push_back(1.0 / range);
+    }
+  }
+
+  NumericVector out(m);
+  std::vector<double> d(n);
+  std::vector<int> idx(n);
+
+  for (int r = 0; r < m; ++r) {
+    // distances
+    if (dist_code == 2) {
+      for (int i = 0; i < n; ++i) {
+        double mismatches = 0.0;
+        for (int j = 0; j < p; ++j)
+          if (rpm_x(i, j) != Xtest(r, j)) mismatches += 1.0;
+        d[i] = mismatches / static_cast<double>(p);
+      }
+    } else if (active.empty()) {
+      std::fill(d.begin(), d.end(), 0.0);
+    } else if (dist_code == 1) {
+      for (int i = 0; i < n; ++i) {
+        double acc = 0.0;
+        for (std::size_t a = 0; a < active.size(); ++a) {
+          const int j = active[a];
+          acc += std::fabs((rpm_x(i, j) - Xtest(r, j)) * inv_range[a]);
+        }
+        d[i] = acc;
+      }
+    } else {
+      for (int i = 0; i < n; ++i) {
+        double acc = 0.0;
+        for (std::size_t a = 0; a < active.size(); ++a) {
+          const int j = active[a];
+          const double z = (rpm_x(i, j) - Xtest(r, j)) * inv_range[a];
+          acc += z * z;
+        }
+        d[i] = std::sqrt(acc);
+      }
+    }
+
+    const int kk = std::min(k, n);
+
+    if (kk == 1) {
+      // Aggregate all exact nearest-distance ties deterministically.
+      double dmin = d[0];
+      for (int i = 1; i < n; ++i) if (d[i] < dmin) dmin = d[i];
+      std::vector<double> tied;
+      for (int i = 0; i < n; ++i) if (d[i] == dmin) tied.push_back(yhat[i]);
+      if (is_class) {
+        std::vector<double> ones(tied.size(), 1.0);
+        out[r] = weighted_mode(tied, ones);
+      } else {
+        // R's gravity() drops nonfinite values before aggregating.
+        std::vector<double> finite_tied;
+        finite_tied.reserve(tied.size());
+        for (double v : tied) if (R_finite(v)) finite_tied.push_back(v);
+        out[r] = gravity_value(finite_tied, false);
+      }
+      continue;
+    }
+
+    // stable ascending order: distance, then original index
+    for (int i = 0; i < n; ++i) idx[i] = i;
+    std::stable_sort(idx.begin(), idx.end(),
+                     [&d](int a, int b) { return d[a] < d[b]; });
+
+    std::vector<double> dk(kk), yk(kk);
+    for (int i = 0; i < kk; ++i) {
+      dk[i] = d[idx[i]];
+      yk[i] = yhat[idx[i]];
+    }
+
+    const std::vector<double> w = ensemble_weights(dk);
+    if (is_class) {
+      out[r] = weighted_mode(yk, w);
+    } else {
+      double dot = 0.0;
+      for (int i = 0; i < kk; ++i) dot += yk[i] * w[i];
+      out[r] = dot;
+    }
+  }
+
+  return out;
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -114,6 +114,42 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// NNS_mreg_predict_path_cpp
+NumericMatrix NNS_mreg_predict_path_cpp(const NumericMatrix& rpm_x, const NumericVector& yhat, const NumericMatrix& Xtest, int kmax, int dist_code, const NumericVector& mins, const NumericVector& maxs, bool is_class);
+RcppExport SEXP _NNS_NNS_mreg_predict_path_cpp(SEXP rpm_xSEXP, SEXP yhatSEXP, SEXP XtestSEXP, SEXP kmaxSEXP, SEXP dist_codeSEXP, SEXP minsSEXP, SEXP maxsSEXP, SEXP is_classSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type rpm_x(rpm_xSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type yhat(yhatSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type Xtest(XtestSEXP);
+    Rcpp::traits::input_parameter< int >::type kmax(kmaxSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_code(dist_codeSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type mins(minsSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type maxs(maxsSEXP);
+    Rcpp::traits::input_parameter< bool >::type is_class(is_classSEXP);
+    rcpp_result_gen = Rcpp::wrap(NNS_mreg_predict_path_cpp(rpm_x, yhat, Xtest, kmax, dist_code, mins, maxs, is_class));
+    return rcpp_result_gen;
+END_RCPP
+}
+// NNS_mreg_predict_cpp
+NumericVector NNS_mreg_predict_cpp(const NumericMatrix& rpm_x, const NumericVector& yhat, const NumericMatrix& Xtest, int k, int dist_code, const NumericVector& mins, const NumericVector& maxs, bool is_class);
+RcppExport SEXP _NNS_NNS_mreg_predict_cpp(SEXP rpm_xSEXP, SEXP yhatSEXP, SEXP XtestSEXP, SEXP kSEXP, SEXP dist_codeSEXP, SEXP minsSEXP, SEXP maxsSEXP, SEXP is_classSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type rpm_x(rpm_xSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type yhat(yhatSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type Xtest(XtestSEXP);
+    Rcpp::traits::input_parameter< int >::type k(kSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_code(dist_codeSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type mins(minsSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type maxs(maxsSEXP);
+    Rcpp::traits::input_parameter< bool >::type is_class(is_classSEXP);
+    rcpp_result_gen = Rcpp::wrap(NNS_mreg_predict_cpp(rpm_x, yhat, Xtest, k, dist_code, mins, maxs, is_class));
+    return rcpp_result_gen;
+END_RCPP
+}
 // NNS_part_cpp
 List NNS_part_cpp(NumericVector x, NumericVector y, Nullable<std::string> type, Nullable<int> order_in, int obs_req, bool min_obs_stop, std::string noise_reduction, bool quadrants_only);
 RcppExport SEXP _NNS_NNS_part_cpp(SEXP xSEXP, SEXP ySEXP, SEXP typeSEXP, SEXP order_inSEXP, SEXP obs_reqSEXP, SEXP min_obs_stopSEXP, SEXP noise_reductionSEXP, SEXP quadrants_onlySEXP) {
@@ -712,6 +748,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_NNS_NNS_distance_bulk_cpp", (DL_FUNC) &_NNS_NNS_distance_bulk_cpp, 5},
     {"_NNS_NNS_distance_path_parallel_cpp", (DL_FUNC) &_NNS_NNS_distance_path_parallel_cpp, 6},
     {"_NNS_NNS_distance_path_single_parallel_cpp", (DL_FUNC) &_NNS_NNS_distance_path_single_parallel_cpp, 6},
+    {"_NNS_NNS_mreg_predict_path_cpp", (DL_FUNC) &_NNS_NNS_mreg_predict_path_cpp, 8},
+    {"_NNS_NNS_mreg_predict_cpp", (DL_FUNC) &_NNS_NNS_mreg_predict_cpp, 8},
     {"_NNS_NNS_part_cpp", (DL_FUNC) &_NNS_NNS_part_cpp, 8},
     {"_NNS_NNS_seas_cpp", (DL_FUNC) &_NNS_NNS_seas_cpp, 3},
     {"_NNS_sd_dom_matrix_prefix_parallel", (DL_FUNC) &_NNS_sd_dom_matrix_prefix_parallel, 3},

--- a/tests/testthat/test-regression-audit-repairs.R
+++ b/tests/testthat/test-regression-audit-repairs.R
@@ -1,0 +1,198 @@
+# REVISION: 2026-07-13-NNS-REGRESSION-AUDIT-TESTS
+
+test_that("NNS.reg preserves warning settings on success and failure", {
+  old <- getOption("warn")
+  on.exit(options(warn = old), add = TRUE)
+  options(warn = 1)
+
+  expect_silent(NNS.reg(1:20, (1:20)^2, plot = FALSE))
+  expect_equal(getOption("warn"), 1)
+
+  expect_error(NNS.reg(1:20, 1:10, plot = FALSE), "rows")
+  expect_equal(getOption("warn"), 1)
+})
+
+test_that("training and response dimensions are checked before fitting", {
+  expect_error(
+    NNS.reg(matrix(1:20, ncol = 2), 1:5, plot = FALSE),
+    "rows"
+  )
+})
+
+test_that("named prediction columns are reordered and schema checked", {
+  set.seed(1)
+  x <- data.frame(a = rnorm(40), b = rnorm(40))
+  y <- x$a - 2 * x$b
+  p1 <- x[1:5, c("a", "b")]
+  p2 <- x[1:5, c("b", "a")]
+
+  f1 <- NNS.reg(x, y, point.est = p1, plot = FALSE,
+                residual.plot = FALSE, ncores = 1)
+  f2 <- NNS.reg(x, y, point.est = p2, plot = FALSE,
+                residual.plot = FALSE, ncores = 1)
+  expect_equal(f1$Point.est, f2$Point.est, tolerance = 1e-12)
+
+  bad <- p1
+  names(bad) <- c("a", "c")
+  expect_error(
+    NNS.reg(x, y, point.est = bad, plot = FALSE,
+            residual.plot = FALSE),
+    "exactly match"
+  )
+})
+
+test_that("dimension reduction is invariant to unrelated prediction rows", {
+  set.seed(2)
+  x <- data.frame(a = rnorm(50), b = rnorm(50), c = rnorm(50))
+  y <- x$a + x$b^2 - x$c
+  base <- x[1:3, ]
+  extra <- rbind(base, data.frame(a = 1e6, b = -1e6, c = 1e6))
+
+  f1 <- NNS.reg(x, y, point.est = base, dim.red.method = "cor",
+                plot = FALSE, residual.plot = FALSE)
+  f2 <- NNS.reg(x, y, point.est = extra, dim.red.method = "cor",
+                plot = FALSE, residual.plot = FALSE)
+  expect_equal(f1$Point.est, f2$Point.est[1:3], tolerance = 1e-12)
+})
+
+test_that("factor encoding is training-fitted and unseen levels fail", {
+  x <- data.frame(group = factor(rep(c("a", "b"), each = 15)),
+                  z = seq_len(30))
+  y <- rep(c(1, 2), each = 15)
+  ok <- data.frame(group = factor(c("a", "b"), levels = c("a", "b")),
+                   z = c(4, 20))
+  expect_silent(
+    NNS.reg(x, y, point.est = ok, type = "CLASS",
+            plot = FALSE, residual.plot = FALSE)
+  )
+
+  bad <- data.frame(group = "c", z = 10)
+  expect_error(
+    NNS.reg(x, y, point.est = bad, type = "CLASS",
+            plot = FALSE, residual.plot = FALSE),
+    "unseen level"
+  )
+})
+
+test_that("classification returns numeric observed class values", {
+  train <- iris[-(141:150), ]
+  test <- iris[141:150, 1:4]
+  fit <- NNS.reg(train[, 1:4], train[, 5], point.est = test,
+                 type = "CLASS", plot = FALSE,
+                 residual.plot = FALSE, ncores = 1)
+  expect_true(is.numeric(fit$Point.est))
+  expect_true(all(fit$Point.est %in% 1:3))
+  expect_identical(fit$class.levels, levels(iris$Species))
+})
+
+test_that("count responses remain regression unless CLASS is explicit", {
+  x <- seq_len(60)
+  y <- rep(1:3, each = 20)
+  regression <- NNS.reg(x, y, plot = FALSE)
+  expect_null(regression$Prediction.Accuracy)
+
+  classification <- NNS.reg(x, y, type = "CLASS", plot = FALSE)
+  expect_true(is.numeric(classification$Prediction.Accuracy))
+})
+
+test_that("XONLY does not activate classification", {
+  x <- seq_len(40)
+  y <- sin(x / 4)
+  fit <- NNS.reg(x, y, type = "XONLY", plot = FALSE)
+  expect_null(fit$Prediction.Accuracy)
+})
+
+test_that("numeric dimension-reduction equation reproduces X star", {
+  set.seed(3)
+  x <- cbind(a = rnorm(40), b = rnorm(40), c = rnorm(40))
+  y <- rowSums(x)
+  coef <- c(2, -1, 0.5)
+  fit <- NNS.reg(x, y, dim.red.method = coef, plot = FALSE)
+
+  mins <- apply(x, 2, min)
+  ranges <- apply(x, 2, max) - mins
+  norm <- matrix(0.5, nrow(x), ncol(x))
+  active <- ranges > 0
+  norm[, active] <- sweep(sweep(x[, active, drop = FALSE], 2,
+                                mins[active], "-"), 2, ranges[active], "/")
+  expected <- as.numeric(norm %*% coef / sum(abs(coef) > 0))
+  expect_equal(as.numeric(fit$x.star$x), expected, tolerance = 1e-12)
+  expect_equal(tail(fit$equation$Coefficient, 1), sum(abs(coef) > 0))
+})
+
+test_that("all-zero dimension weights fall back to a defined model", {
+  x <- cbind(a = rep(1, 30), b = rep(2, 30))
+  y <- seq_len(30)
+  fit <- NNS.reg(x, y, dim.red.method = c(0, 0), plot = FALSE)
+  expect_true(all(is.finite(fit$x.star$x)))
+  expect_gt(tail(fit$equation$Coefficient, 1), 0)
+})
+
+test_that("order max fitted values use the same prediction function", {
+  x <- c(1, 1, 2, 3, 4, 5)
+  y <- c(1, 3, 4, 9, 16, 25)
+  fit <- NNS.reg(x, y, order = "max", point.est = x, plot = FALSE)
+  expect_equal(fit$Fitted.xy$y.hat, fit$Point.est, tolerance = 1e-12)
+})
+
+test_that("one-row matrix and vector predictions are identical", {
+  set.seed(4)
+  x <- cbind(a = rnorm(50), b = rnorm(50))
+  y <- x[, 1] - x[, 2]
+  v <- unname(x[5, ])
+  m <- matrix(v, nrow = 1)
+
+  fv <- NNS.reg(x, y, point.est = v, plot = FALSE,
+                residual.plot = FALSE, ncores = 1)
+  fm <- NNS.reg(x, y, point.est = m, plot = FALSE,
+                residual.plot = FALSE, ncores = 1)
+  expect_equal(fv$Point.est, fm$Point.est, tolerance = 1e-12)
+})
+
+test_that("n.best one fitted values equal predictions on training rows", {
+  set.seed(5)
+  x <- cbind(a = rnorm(40), b = rnorm(40))
+  y <- x[, 1]^2 + x[, 2]
+  fit <- NNS.reg(x, y, point.est = x, n.best = 1,
+                 plot = FALSE, residual.plot = FALSE, ncores = 1)
+  expect_equal(fit$Fitted.xy$y.hat, fit$Point.est, tolerance = 1e-12)
+})
+
+test_that("distance modes are validated and recorded", {
+  set.seed(6)
+  x <- cbind(a = rnorm(30), b = rnorm(30))
+  y <- x[, 1] + x[, 2]
+  for (d in c("L1", "L2", "FACTOR")) {
+    fit <- NNS.reg(x, y, point.est = x[1:2, ], dist = d,
+                   plot = FALSE, residual.plot = FALSE)
+    expect_identical(fit$dist, d)
+  }
+  expect_error(NNS.reg(x, y, dist = "DTW", plot = FALSE), "dist")
+})
+
+test_that("prediction intervals preserve prediction row count", {
+  x <- seq_len(40)
+  y <- x + sin(x)
+  points <- c(-10, 1, 20, 50)
+  fit <- NNS.reg(x, y, point.est = points,
+                 confidence.interval = 0.9, plot = FALSE)
+  expect_equal(nrow(fit$pred.int), length(points))
+  expect_true(all(fit$pred.int$pred.int.neg <= fit$pred.int$pred.int.pos))
+})
+
+test_that("missing and nonfinite prediction values fail", {
+  x <- cbind(a = 1:20, b = 21:40)
+  y <- 1:20
+  expect_error(
+    NNS.reg(x, y, point.est = matrix(c(NA, 2), nrow = 1),
+            plot = FALSE, residual.plot = FALSE),
+    "finite"
+  )
+})
+
+test_that("NNS.part order max never passes a character value to C++", {
+  fit <- NNS.part(c(1, 1, 2, 3), c(1, 3, 4, 9),
+                  order = "max", type = "XONLY")
+  expect_equal(nrow(fit$regression.points), 3)
+  expect_identical(fit$order, 3L)
+})


### PR DESCRIPTION
Builds on #41 (branch includes its commit). **Rebuilt on the updated `NNS-Beta-Version`** — the base now carries the pure-R audit repairs, so this PR is the performance-restoration delta; conflicts resolved.

## Changes

1. **`src/NNS_mreg_predict.cpp`** — `NNS_mreg_predict_cpp` and `NNS_mreg_predict_path_cpp` implement the repaired multivariate prediction rule natively and exactly: range-normalized L1/L2/FACTOR dispatch, stable tie ordering, k=1 exact-tie aggregation via `gravity_value`, the eight-component ensemble weights via Rmath (bit-matching R's `dt`/`dexp`/`dlnorm`/`dnorm`), exact double-precision weighted class mode. Serial by design — no global RcppParallel state.
2. **`R/Multivariate_Regression.R`** — `.nns_mreg_predict` dispatches to the kernel; the pure-R rule is retained as `.nns_mreg_predict_reference` for equivalence testing. Singleton-cell fast path in the RPM builder (the common continuous case skips the per-group reducer).
3. **`R/Stack.R`** — multivariate method-1 CV scores every `n.best` candidate through `NNS_mreg_predict_path_cpp`, the same estimator the final `NNS.reg` fit uses (review finding on the previous revision), replacing the stale `NNS.distance.path.bulk` scoring and its gradient extrapolation — the repaired `NNS.M.reg` no longer extrapolates outside training support, so CV doesn't either.
4. **`tests/testthat/test-regression-audit-repairs.R`** — bundled audit regression tests (32 assertions, passing).

## Validation (live R, package built from this branch)

- Kernel ≡ pure-R reference (≤3e-15 across k grids on L1+L2; class mode identical).
- CV path column k ≡ `NNS.reg(n.best = k)` final predictions, bit-identical.
- `cbind(x, x)` increasing-dimensions idiom works (base's own name-normalization fix verified preserved).
- `NNSvignette_07_Clustering_and_Regression.Rmd` rebuilds clean.
- **Performance**: 500×5 point-estimation workload drops 0.82s (pure-R base) → **0.13s** with the kernel.

## Downstream

Python port re-sync to the repaired semantics (metric, R², class maps, train-only normalization, rounding) starts once this merges — parity caches will be regenerated against the merged R.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPbZvtDw4h2XJo9w5hw57h