### PR TITLE
Maximize audit-safe NNS.stack native performance

### DIFF
--- a/R/Multivariate_Regression.R
+++ b/R/Multivariate_Regression.R
@@ -17,29 +17,29 @@
 .nns_mreg_ensemble_weights <- function(distances) {
   k <- length(distances)
   if (k == 1L) return(1)
-  
+
   ranks <- seq_len(k)
   uniform <- rep(1 / k, k)
   student <- .nns_mreg_normalize_weights(stats::dt(distances, df = k))
   inverse <- .nns_mreg_normalize_weights(1 / pmax(distances, 1e-12))
   exponential <- .nns_mreg_normalize_weights(stats::dexp(ranks, rate = 1 / k))
-  
+
   rank.sd <- stats::sd(ranks)
   lognormal <- if (is.finite(rank.sd) && rank.sd > 0) {
     rev(.nns_mreg_normalize_weights(abs(stats::dlnorm(ranks, 0, rank.sd, log = TRUE))))
   } else rep(0, k)
-  
+
   power <- .nns_mreg_normalize_weights(ranks^(-2))
   distance.sd <- stats::sd(distances)
   normal <- if (is.finite(distance.sd) && distance.sd > 0) {
     .nns_mreg_normalize_weights(stats::dnorm(distances, 0, distance.sd))
   } else rep(0, k)
-  
+
   distance.var <- stats::var(distances)
   rbf <- if (is.finite(distance.var) && distance.var > 0) {
     .nns_mreg_normalize_weights(exp(-distances / (2 * distance.var)))
   } else rep(0, k)
-  
+
   .nns_mreg_normalize_weights(
     uniform + student + inverse + exponential + lognormal + power + normal + rbf
   )
@@ -50,20 +50,20 @@
   if (any(!is.finite(destination))) {
     stop("[point.est] contains missing or nonfinite values.", call. = FALSE)
   }
-  
+
   if (dist == "FACTOR") {
     # Encoded categorical predictors are represented by stable training-fitted
     # dummy/code columns. Hamming distance is therefore the coherent categorical
     # metric and does not invent an ordering among unequal categories.
     return(rowMeans(sweep(rpm.x, 2L, destination, "!=") * 1))
   }
-  
+
   ranges <- maximums - minimums
   active <- is.finite(ranges) & ranges > 0
   if (!any(active)) return(rep(0, nrow(rpm.x)))
   z <- sweep(rpm.x[, active, drop = FALSE], 2L, destination[active], "-")
   z <- sweep(z, 2L, ranges[active], "/")
-  
+
   if (dist == "L1") rowSums(abs(z)) else sqrt(rowSums(z^2))
 }
 
@@ -73,7 +73,7 @@
   d <- .nns_mreg_distance_vector(rpm.x, destination, dist, minimums, maximums)
   ord <- order(d, seq_along(d), method = "radix")
   k <- min(k, length(ord))
-  
+
   # For k = 1, aggregate all exact nearest-distance ties deterministically.
   if (k == 1L) {
     tied <- which(d == min(d))
@@ -81,7 +81,7 @@
     if (is.class) return(.nns_mreg_weighted_mode(vals, rep(1, length(vals))))
     return(gravity(vals))
   }
-  
+
   idx <- ord[seq_len(k)]
   w <- .nns_mreg_ensemble_weights(d[idx])
   if (is.class) .nns_mreg_weighted_mode(rpm$y.hat[idx], w) else
@@ -101,7 +101,7 @@
   if (any(!is.finite(Xtest))) {
     stop("[point.est] contains missing or nonfinite values.", call. = FALSE)
   }
-  
+
   # Native serial kernel implementing exactly .nns_mreg_predict_one:
   # same metric dispatch, stable tie ordering, k = 1 tie aggregation, ensemble
   # weights, and exact weighted class mode. No global thread state is touched.
@@ -109,10 +109,17 @@
   storage.mode(rpm.x) <- "double"
   storage.mode(Xtest) <- "double"
   dist.code <- match(dist, c("L2", "L1", "FACTOR")) - 1L
-  as.numeric(NNS_mreg_predict_cpp(
-    rpm.x, as.numeric(rpm$y.hat), Xtest, as.integer(k), dist.code,
-    as.numeric(minimums), as.numeric(maximums), isTRUE(is.class)
-  ))
+  as.numeric(if (isTRUE(getOption("NNS.native.mreg", TRUE))) {
+    NNS_mreg_predict_v2_cpp(
+      rpm.x, as.numeric(rpm$y.hat), Xtest, as.integer(k), dist.code,
+      as.numeric(minimums), as.numeric(maximums), isTRUE(is.class), as.integer(ncores)
+    )
+  } else {
+    NNS_mreg_predict_cpp(
+      rpm.x, as.numeric(rpm$y.hat), Xtest, as.integer(k), dist.code,
+      as.numeric(minimums), as.numeric(maximums), isTRUE(is.class)
+    )
+  })
 }
 
 # Reference pure-R implementation of the prediction rule, retained for
@@ -156,34 +163,28 @@
 .nns_mreg_partition_matrix <- function(X, y, order, noise.reduction, is.class) {
   p <- ncol(X)
   boundaries <- vector("list", p)
-  
-  if (identical(order, "max")) {
-    for (j in seq_len(p)) boundaries[[j]] <- sort(unique(X[, j]))
-  } else {
-    for (j in seq_len(p)) {
-      rp <- NNS.reg(
-        X[, j], y,
-        factor.2.dummy = FALSE,
-        order = order,
-        type = if (is.class) "CLASS" else NULL,
-        plot = FALSE,
-        smooth = FALSE,
-        noise.reduction = noise.reduction,
-        point.only = FALSE,
-        multivariate.call = TRUE
+  reps <- if (isTRUE(getOption("NNS.native.mreg", TRUE))) {
+    tryCatch(as.integer(NNS_duplicate_column_map_cpp(as.matrix(X))),
+             error = function(e) seq_len(p))
+  } else seq_len(p)
+  for (j in seq_len(p)) {
+    r <- reps[j]
+    if (r < j && !is.null(boundaries[[r]])) {
+      boundaries[[j]] <- boundaries[[r]]
+      next
+    }
+    if (identical(order, "max")) {
+      boundaries[[j]] <- sort(unique(X[, j]))
+    } else {
+      boundaries[[j]] <- .nns_reg_partition_points_fast(
+        X[, j], y, order = order, noise.reduction = noise.reduction,
+        is.class = is.class
       )
-      boundaries[[j]] <- sort(unique(as.numeric(rp$x)))
-      if (!length(boundaries[[j]])) boundaries[[j]] <- sort(unique(X[, j]))
     }
   }
-  
   max.length <- max(lengths(boundaries))
-  rhs <- do.call(cbind, lapply(boundaries, function(z) {
-    length(z) <- max.length
-    z
-  }))
+  rhs <- do.call(cbind, lapply(boundaries, function(z) { length(z) <- max.length; z }))
   colnames(rhs) <- colnames(X)
-  
   id.parts <- lapply(seq_len(p), function(j) {
     findInterval(X[, j], boundaries[[j]], left.open = FALSE,
                  rightmost.closed = TRUE)
@@ -191,6 +192,39 @@
   ids <- do.call(paste, c(as.data.frame(id.parts), sep = "."))
   list(rhs = rhs, ids = ids, boundaries = boundaries)
 }
+
+.nns_mreg_prepare_model <- function(
+    X,
+    y,
+    order = NULL,
+    noise.reduction = "off",
+    is.class = FALSE,
+    use.native = isTRUE(getOption("NNS.native.mreg", TRUE))
+) {
+  X <- as.data.frame(X, check.names = FALSE)
+  y <- as.numeric(y)
+  minimums <- vapply(X, min, numeric(1L))
+  maximums <- vapply(X, max, numeric(1L))
+  partition <- .nns_mreg_partition_matrix(X, y, order, noise.reduction, is.class)
+  reducer_code <- switch(noise.reduction, mean = 0L, median = 1L, mode = 2L, off = 3L)
+  if (use.native) {
+    native <- tryCatch(NNS_mreg_setup_cpp(as.matrix(X), y, partition$boundaries,
+                                          reducer_code, is.class),
+                       error = function(e) NULL)
+    if (!is.null(native)) {
+      rpm <- as.data.frame(native$RPM, stringsAsFactors = FALSE)
+      names(rpm) <- c(colnames(X), "y.hat")
+      rownames(rpm) <- NULL
+      return(list(RPM = rpm, rhs.partitions = partition$rhs, ids = partition$ids,
+                  boundaries = partition$boundaries, minimums = minimums,
+                  maximums = maximums))
+    }
+  }
+  rpm <- .nns_mreg_build_rpm(X, y, partition$ids, noise.reduction, is.class)
+  list(RPM = rpm, rhs.partitions = partition$rhs, ids = partition$ids,
+       boundaries = partition$boundaries, minimums = minimums, maximums = maximums)
+}
+
 
 .nns_mreg_default_nbest <- function(X, y, rpm.rows) {
   dep <- tryCatch(NNS.copula(cbind(X, y)), error = function(e) NA_real_)
@@ -216,7 +250,7 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
                       noise.reduction = "off", dist = "L2",
                       return.values = FALSE, plot.regions = FALSE,
                       ncores = NULL, confidence.interval = NULL) {
-  
+
   factor.2.dummy <- .nns_reg_scalar_logical(factor.2.dummy, "factor.2.dummy")
   point.only <- .nns_reg_scalar_logical(point.only, "point.only")
   plot <- .nns_reg_scalar_logical(plot, "plot")
@@ -229,7 +263,7 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
   noise.reduction <- .nns_reg_validate_noise(noise.reduction)
   confidence.interval <- .nns_reg_validate_ci(confidence.interval)
   ncores <- .nns_mreg_validate_cores(ncores)
-  
+
   if (!is.null(type) && (!is.character(type) || length(type) != 1L ||
                          is.na(type) || tolower(type) != "class")) {
     stop("NNS.M.reg [type] must be NULL or 'CLASS'.", call. = FALSE)
@@ -237,12 +271,12 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
   Y <- .nns_reg_response_vector(Y)
   task <- .nns_reg_type(if (is.null(type)) NULL else "CLASS", Y)
   is.class <- task$is.class
-  
+
   encoded <- .nns_reg_encode_predictors(X_n, point.est, factor.2.dummy)
   X <- encoded$x
   Xpoint <- encoded$point.est
   y <- task$y
-  
+
   if (nrow(X) != length(y)) {
     stop(sprintf("[X_n] has %d rows but [Y] has %d values.",
                  nrow(X), length(y)), call. = FALSE)
@@ -253,18 +287,14 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
   if (length(y) < 2L || any(!is.finite(y))) {
     stop("[Y] must contain at least two finite values.", call. = FALSE)
   }
-  
-  minimums <- apply(X, 2L, min)
-  maximums <- apply(X, 2L, max)
-  
-  partition <- .nns_mreg_partition_matrix(
-    X, y, order, noise.reduction, is.class
-  )
-  rpm <- .nns_mreg_build_rpm(
-    X, y, partition$ids, noise.reduction, is.class
-  )
+
+  prepared <- .nns_mreg_prepare_model(X, y, order, noise.reduction, is.class)
+  minimums <- prepared$minimums
+  maximums <- prepared$maximums
+  partition <- list(rhs = prepared$rhs.partitions, ids = prepared$ids, boundaries = prepared$boundaries)
+  rpm <- prepared$RPM
   if (!nrow(rpm)) stop("NNS.M.reg produced an empty RPM.", call. = FALSE)
-  
+
   if (is.null(n.best) && identical(order, "max")) {
     k <- 1L
   } else if (is.null(n.best)) {
@@ -275,7 +305,7 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
     k <- min(as.integer(n.best), nrow(rpm))
   }
   k <- max(1L, k)
-  
+
   # Fitted values and point estimates always use the same exact prediction rule.
   fitted.pred <- .nns_mreg_predict(
     X, rpm, k, dist, minimums, maximums, is.class, ncores
@@ -283,19 +313,19 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
   point.pred <- .nns_mreg_predict(
     Xpoint, rpm, k, dist, minimums, maximums, is.class, ncores
   )
-  
+
   if (is.class) {
     observed <- sort(unique(y))
     fitted.pred <- .nns_reg_snap_class(fitted.pred, observed)
     if (!is.null(point.pred)) point.pred <- .nns_reg_snap_class(point.pred, observed)
   }
-  
+
   fitted <- as.data.frame(X, stringsAsFactors = FALSE)
   fitted$y <- y
   fitted$y.hat <- fitted.pred
   fitted$NNS.ID <- partition$ids
   fitted$residuals <- fitted.pred - y
-  
+
   metric <- if (is.class) mean(fitted.pred == y) else
     .nns_reg_r2(y, fitted.pred)
   intervals <- .nns_reg_intervals(
@@ -306,7 +336,7 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
     fitted$conf.int.neg <- intervals$conf.lower
     fitted$conf.int.pos <- intervals$conf.upper
   }
-  
+
   if (point.only) {
     return(list(
       R2 = NULL,
@@ -320,7 +350,7 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
       class.levels = task$class.levels
     ))
   }
-  
+
   if (plot && ncol(X) == 2L) {
     .nns_require_rgl()
     rgl::plot3d(X[, 1L], X[, 2L], y, box = FALSE, size = 3,
@@ -332,7 +362,7 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
       rgl::points3d(Xpoint[, 1L], Xpoint[, 2L], point.pred,
                     col = "green", size = 5)
     }
-    
+
     if (plot.regions) {
       for (id in unique(partition$ids)) {
         idx <- partition$ids == id
@@ -347,7 +377,7 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
       }
     }
   }
-  
+
   if (residual.plot) {
     graphics::plot(seq_along(y), y, pch = 1, lwd = 2,
                    col = "steelblue", xlab = "Index",
@@ -366,7 +396,7 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
     graphics::legend(if (is.null(location)) "top" else location,
                      legend = label, bty = "n")
   }
-  
+
   out <- list(
     R2 = metric,
     rhs.partitions = .NNS.df(as.data.frame(partition$rhs)),
@@ -378,6 +408,6 @@ NNS.M.reg <- function(X_n, Y, factor.2.dummy = TRUE, order = NULL,
     dist = dist,
     class.levels = task$class.levels
   )
-  
+
   if (return.values) out else invisible(out)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -36,6 +36,26 @@ NNS_mreg_predict_path_cpp <- function(rpm_x, yhat, Xtest, kmax, dist_code, mins,
 NNS_mreg_predict_cpp <- function(rpm_x, yhat, Xtest, k, dist_code, mins, maxs, is_class) {
     .Call(`_NNS_NNS_mreg_predict_cpp`, rpm_x, yhat, Xtest, k, dist_code, mins, maxs, is_class)
 }
+NNS_mreg_predict_path_v2_cpp <- function(rpm_x, yhat, Xtest, kmax, dist_code, mins, maxs, is_class, nthreads) {
+    .Call(`_NNS_NNS_mreg_predict_path_v2_cpp`, rpm_x, yhat, Xtest, kmax, dist_code, mins, maxs, is_class, nthreads)
+}
+
+NNS_mreg_predict_v2_cpp <- function(rpm_x, yhat, Xtest, k, dist_code, mins, maxs, is_class, nthreads) {
+    .Call(`_NNS_NNS_mreg_predict_v2_cpp`, rpm_x, yhat, Xtest, k, dist_code, mins, maxs, is_class, nthreads)
+}
+
+NNS_duplicate_column_map_cpp <- function(X) {
+    .Call(`_NNS_NNS_duplicate_column_map_cpp`, X)
+}
+
+NNS_mreg_setup_cpp <- function(X, y, boundaries, reducer_code, is_class) {
+    .Call(`_NNS_NNS_mreg_setup_cpp`, X, y, boundaries, reducer_code, is_class)
+}
+
+NNS_xstar_path_cpp <- function(train_design, test_design, coefficients, column_order, nthreads) {
+    .Call(`_NNS_NNS_xstar_path_cpp`, train_design, test_design, coefficients, column_order, nthreads)
+}
+
 
 NNS_part_cpp <- function(x, y, type, order_in, obs_req, min_obs_stop, noise_reduction, quadrants_only = FALSE) {
     .Call(`_NNS_NNS_part_cpp`, x, y, type, order_in, obs_req, min_obs_stop, noise_reduction, quadrants_only)

--- a/R/Regression.R
+++ b/R/Regression.R
@@ -30,14 +30,14 @@
       stop("[type] must be NULL, 'CLASS', or 'XONLY'.", call. = FALSE)
     }
   }
-  
+
   auto.class <- is.factor(y) || is.character(y) || is.logical(y) ||
     (is.numeric(y) && length(unique(y)) == 2L &&
        setequal(sort(unique(as.numeric(y))), c(0, 1)))
-  
+
   is.class <- identical(type, "class") || (is.null(type) && auto.class)
   is.xonly <- identical(type, "xonly")
-  
+
   if (is.factor(y)) {
     class.levels <- levels(y)
     y.numeric <- as.numeric(y)
@@ -56,7 +56,7 @@
     class.values <- if (is.class) sort(unique(y.numeric)) else NULL
     class.levels <- if (is.class) as.character(class.values) else NULL
   }
-  
+
   list(
     type = if (is.class) "class" else if (is.xonly) "xonly" else NULL,
     is.class = is.class,
@@ -143,7 +143,7 @@
 .nns_reg_prepare_points <- function(point.est, train.names) {
   if (is.null(point.est)) return(NULL)
   p <- length(train.names)
-  
+
   if (p == 1L) {
     if (is.null(dim(point.est))) {
       out <- data.frame(point.est, check.names = FALSE)
@@ -163,7 +163,7 @@
     names(out) <- train.names
     return(out)
   }
-  
+
   if (is.null(dim(point.est))) {
     if (length(point.est) != p) {
       stop(sprintf("A vector [point.est] must have exactly %d values.", p), call. = FALSE)
@@ -185,14 +185,14 @@
     names(out) <- train.names
     return(out)
   }
-  
+
   supplied.names <- colnames(point.est)
   has.supplied.names <- !is.null(supplied.names) && all(nzchar(supplied.names))
   out <- as.data.frame(point.est, check.names = FALSE, stringsAsFactors = FALSE)
   if (ncol(out) != p) {
     stop(sprintf("[point.est] must contain exactly %d predictor columns.", p), call. = FALSE)
   }
-  
+
   if (has.supplied.names) {
     # Training names are normalized with make.unique() in .nns_reg_as_frame().
     # Normalize prediction names identically before validating/reordering so
@@ -215,18 +215,18 @@
   factor.2.dummy <- .nns_reg_scalar_logical(factor.2.dummy, "factor.2.dummy")
   train <- .nns_reg_as_frame(x)
   points <- .nns_reg_prepare_points(point.est, names(train))
-  
+
   train.parts <- list()
   point.parts <- if (is.null(points)) NULL else list()
   meta <- vector("list", ncol(train))
-  
+
   for (j in seq_along(train)) {
     nm <- names(train)[j]
     z <- train[[j]]
     zp <- if (is.null(points)) NULL else points[[j]]
-    
+
     categorical <- is.factor(z) || is.character(z) || is.logical(z)
-    
+
     if (categorical) {
       levels.train <- if (is.factor(z)) levels(z) else unique(as.character(z))
       values.train <- as.character(z)
@@ -247,14 +247,14 @@
       } else {
         values.point <- NULL
       }
-      
+
       if (factor.2.dummy) {
         tr <- outer(values.train, levels.train, FUN = function(a, b) as.numeric(a == b))
         if (is.null(dim(tr))) tr <- matrix(tr, nrow = length(values.train),
                                            ncol = length(levels.train))
         colnames(tr) <- paste0(nm, "_", make.names(levels.train, unique = TRUE))
         train.parts[[length(train.parts) + 1L]] <- tr
-        
+
         if (!is.null(points)) {
           pt <- outer(values.point, levels.train, FUN = function(a, b) as.numeric(a == b))
           if (is.null(dim(pt))) pt <- matrix(pt, nrow = length(values.point),
@@ -272,7 +272,7 @@
           point.parts[[length(point.parts) + 1L]] <- pt
         }
       }
-      
+
       meta[[j]] <- list(name = nm, categorical = TRUE, levels = levels.train)
     } else {
       tr <- suppressWarnings(as.numeric(z))
@@ -282,7 +282,7 @@
       }
       tr <- matrix(tr, ncol = 1L, dimnames = list(NULL, nm))
       train.parts[[length(train.parts) + 1L]] <- tr
-      
+
       if (!is.null(points)) {
         pt <- if (is.factor(zp) || is.character(zp)) {
           suppressWarnings(as.numeric(as.character(zp)))
@@ -299,12 +299,12 @@
       meta[[j]] <- list(name = nm, categorical = FALSE, levels = NULL)
     }
   }
-  
+
   x.matrix <- do.call(cbind, train.parts)
   storage.mode(x.matrix) <- "double"
   point.matrix <- if (is.null(points)) NULL else do.call(cbind, point.parts)
   if (!is.null(point.matrix)) storage.mode(point.matrix) <- "double"
-  
+
   list(
     x = x.matrix,
     point.est = point.matrix,
@@ -359,7 +359,7 @@
 .nns_reg_build_points <- function(x, y, order, noise.reduction,
                                   is.class, xonly = FALSE) {
   reducer <- function(z) .nns_reg_reduce_value(z, noise.reduction, is.class)
-  
+
   if (identical(order, "max")) {
     split.y <- split(y, x)
     xs <- as.numeric(names(split.y))
@@ -372,11 +372,11 @@
                      min.obs.stop = TRUE, noise.reduction = nr)
     rp <- as.data.frame(part$regression.points[, c("x", "y"), drop = FALSE])
   }
-  
+
   rp <- rp[is.finite(rp$x) & is.finite(rp$y), , drop = FALSE]
   if (!nrow(rp)) stop("NNS regression produced no finite regression points.", call. = FALSE)
   rp <- rp[order(rp$x, method = "radix"), , drop = FALSE]
-  
+
   if (anyDuplicated(rp$x)) {
     groups <- split(rp$y, rp$x)
     rp <- data.frame(
@@ -385,7 +385,7 @@
     )
     rp <- rp[order(rp$x, method = "radix"), , drop = FALSE]
   }
-  
+
   # Always include training boundaries using the same response reducer.
   xmin <- min(x)
   xmax <- max(x)
@@ -466,7 +466,7 @@
                                   na.rm = TRUE, names = FALSE, type = 8))
   conf.lower <- fitted + q[1L]
   conf.upper <- fitted + q[2L]
-  
+
   pred.int <- NULL
   if (!is.null(point.pred)) {
     lower <- point.pred + q[1L]
@@ -504,23 +504,23 @@
     }
     method <- "numeric"
   }
-  
+
   if (!is.numeric(threshold) || length(threshold) != 1L ||
       !is.finite(threshold) || threshold < 0) {
     stop("[threshold] must be a single finite nonnegative number.", call. = FALSE)
   }
-  
+
   cor.coef <- vapply(seq_len(p), function(j) {
     z <- suppressWarnings(stats::cor(x[, j], y, method = "spearman"))
     if (is.finite(z)) z else 0
   }, numeric(1L))
-  
+
   dep.coef <- function() vapply(seq_len(p), function(j) {
     z <- tryCatch(NNS.dep(x[, j], y, print.map = FALSE, asym = TRUE)$Dependence,
                   error = function(e) 0)
     if (is.finite(z)) z else 0
   }, numeric(1L))
-  
+
   caus.coef <- function() {
     if (is.null(tau)) tau.use <- "cs" else {
       if (!is.character(tau) || length(tau) != 1L || is.na(tau) ||
@@ -535,7 +535,7 @@
       if (is.finite(z)) z else 0
     }, numeric(1L))
   }
-  
+
   coef <- switch(method,
                  cor = cor.coef,
                  nns.dep = dep.coef(),
@@ -544,7 +544,7 @@
                                       rep(1, p))),
                  equal = rep(1, p),
                  numeric = as.numeric(dim.red.method))
-  
+
   preserved <- coef
   coef[abs(coef) < threshold] <- 0
   if (!any(abs(coef) > 0)) {
@@ -559,7 +559,7 @@
   mins <- apply(x, 2L, min)
   maxs <- apply(x, 2L, max)
   ranges <- maxs - mins
-  
+
   normalize <- function(m) {
     out <- matrix(0.5, nrow = nrow(m), ncol = ncol(m),
                   dimnames = dimnames(m))
@@ -570,12 +570,12 @@
     }
     out
   }
-  
+
   nx <- normalize(x)
   np <- if (is.null(point.est)) NULL else normalize(point.est)
   denominator <- sum(abs(coef) > 0)
   if (denominator < 1L) stop("Dimension reduction retained no predictors.", call. = FALSE)
-  
+
   x.star <- as.numeric((nx %*% coef) / denominator)
   point.star <- if (is.null(np)) NULL else as.numeric((np %*% coef) / denominator)
   equation <- data.frame(
@@ -621,6 +621,30 @@
 #' @return A list containing model diagnostics, point estimates, intervals,
 #' regression points, fitted values, and dimension-reduction information where applicable.
 #' @export
+
+.nns_reg_partition_points_fast <- function(x, y, order = NULL,
+                                           noise.reduction = "off",
+                                           is.class = FALSE) {
+  rp <- .nns_reg_build_points(as.numeric(x), as.numeric(y), order,
+                              noise.reduction, is.class, xonly = TRUE)
+  out <- sort(unique(as.numeric(rp[, 1L])))
+  if (!length(out)) out <- sort(unique(as.numeric(x)))
+  out
+}
+
+.nns_reg_univariate_fast <- function(train_x, train_y, test_x, order = NULL,
+                                     noise.reduction = "off",
+                                     is.class = FALSE,
+                                     class.values = NULL) {
+  rp <- .nns_reg_build_points(as.numeric(train_x), as.numeric(train_y),
+                              order, noise.reduction, is.class)
+  pred <- .nns_reg_predict_univariate(as.numeric(test_x), rp, smooth = FALSE,
+                                      is.class = is.class,
+                                      class.values = class.values)
+  list(prediction = pred, regression.points = rp,
+       order = if (is.null(order)) .nns_reg_default_order(as.numeric(train_x), as.numeric(train_y)) else order)
+}
+
 NNS.reg <- function(x, y,
                     factor.2.dummy = TRUE, order = NULL,
                     dim.red.method = NULL, tau = NULL,
@@ -638,7 +662,7 @@ NNS.reg <- function(x, y,
                     ncores = NULL,
                     point.only = FALSE,
                     multivariate.call = FALSE) {
-  
+
   factor.2.dummy <- .nns_reg_scalar_logical(factor.2.dummy, "factor.2.dummy")
   return.values <- .nns_reg_scalar_logical(return.values, "return.values")
   plot <- .nns_reg_scalar_logical(plot, "plot")
@@ -653,25 +677,25 @@ NNS.reg <- function(x, y,
   noise.reduction <- .nns_reg_validate_noise(noise.reduction)
   confidence.interval <- .nns_reg_validate_ci(confidence.interval)
   if (!plot) residual.plot <- FALSE
-  
+
   y <- .nns_reg_response_vector(y)
   if (length(y) < 2L) stop("[y] must contain at least two observations.", call. = FALSE)
   if (anyNA(y)) stop("[y] contains missing values.", call. = FALSE)
-  
+
   task <- .nns_reg_type(type, y)
   y.numeric <- task$y
   if (any(!is.finite(y.numeric))) stop("[y] must contain finite values.", call. = FALSE)
-  
+
   encoded <- .nns_reg_encode_predictors(x, point.est, factor.2.dummy)
   if (nrow(encoded$x) != length(y.numeric)) {
     stop(sprintf("[x] has %d rows but [y] has %d values.",
                  nrow(encoded$x), length(y.numeric)), call. = FALSE)
   }
-  
+
   if (task$is.xonly && ncol(encoded$x) != 1L) {
     stop("[type = 'XONLY'] is only valid for a single encoded predictor.", call. = FALSE)
   }
-  
+
   # Full multivariate regression.
   if (ncol(encoded$x) > 1L && is.null(dim.red.method)) {
     ans <- NNS.M.reg(
@@ -696,10 +720,10 @@ NNS.reg <- function(x, y,
     ans$class.levels <- task$class.levels
     if (return.values) return(ans) else return(invisible(ans))
   }
-  
+
   synthetic.x.equation <- NULL
   x.star <- NULL
-  
+
   # Dimension reduction converts the encoded matrix to one training-fitted X*.
   if (ncol(encoded$x) > 1L) {
     dr <- .nns_reg_dimreduce(encoded$x, encoded$point.est, y.numeric,
@@ -713,14 +737,14 @@ NNS.reg <- function(x, y,
     up <- if (is.null(encoded$point.est)) NULL else
       as.numeric(encoded$point.est[, 1L])
   }
-  
+
   rp <- .nns_reg_build_points(ux, y.numeric, order, noise.reduction,
                               task$is.class, task$is.xonly)
-  
+
   if (multivariate.call) {
     return(.NNS.df(rp[, c("x", "y"), drop = FALSE]))
   }
-  
+
   fitted.pred <- .nns_reg_predict_univariate(
     ux, rp, smooth = smooth, is.class = task$is.class,
     class.values = task$class.values
@@ -729,14 +753,14 @@ NNS.reg <- function(x, y,
     up, rp, smooth = smooth, is.class = task$is.class,
     class.values = task$class.values
   )
-  
+
   derivative <- .nns_reg_derivative(rp)
   ids <- findInterval(ux, rp$x, left.open = FALSE, rightmost.closed = TRUE)
   ids <- pmax(1L, pmin(ids, nrow(rp)))
   grad.idx <- findInterval(ux, derivative$X.Lower.Range,
                            left.open = FALSE, rightmost.closed = TRUE)
   grad.idx <- pmax(1L, pmin(grad.idx, nrow(derivative)))
-  
+
   fitted <- data.frame(
     x = ux,
     y = y.numeric,
@@ -746,7 +770,7 @@ NNS.reg <- function(x, y,
     residuals = fitted.pred - y.numeric,
     stringsAsFactors = FALSE
   )
-  
+
   metric <- if (task$is.class) mean(fitted.pred == y.numeric) else
     .nns_reg_r2(y.numeric, fitted.pred)
   se <- sqrt(mean((fitted.pred - y.numeric)^2))
@@ -758,7 +782,7 @@ NNS.reg <- function(x, y,
     fitted$conf.int.neg <- intervals$conf.lower
     fitted$conf.int.pos <- intervals$conf.upper
   }
-  
+
   if (point.only) {
     out <- list(
       R2 = NULL,
@@ -775,7 +799,7 @@ NNS.reg <- function(x, y,
     )
     return(out)
   }
-  
+
   if (plot) {
     xlim <- range(c(ux, up), finite = TRUE)
     ylim <- range(c(y.numeric, fitted.pred, point.pred, rp$y,
@@ -799,7 +823,7 @@ NNS.reg <- function(x, y,
       bquote(bold(R^2 == .(format(metric, digits = 4))))
     graphics::legend(location, legend = label, bty = "n")
   }
-  
+
   out <- list(
     R2 = metric,
     SE = se,
@@ -813,6 +837,6 @@ NNS.reg <- function(x, y,
     Fitted.xy = .NNS.df(fitted),
     class.levels = task$class.levels
   )
-  
+
   if (return.values) out else invisible(out)
 }

--- a/R/Stack.R
+++ b/R/Stack.R
@@ -105,18 +105,18 @@ NNS.stack <- function(IVs.train,
                       status = TRUE,
                       ncores = NULL,
                       seed = 123L) {
-  
+
   # -------------------------------------------------------------------------
   # Validation, coercion, and state helpers
   # -------------------------------------------------------------------------
-  
+
   .scalar_logical <- function(x, name) {
     if (!is.logical(x) || length(x) != 1L || is.na(x)) {
       stop(sprintf("[%s] must be TRUE or FALSE.", name), call. = FALSE)
     }
     x
   }
-  
+
   .scalar_integer <- function(x, name, minimum = 0L, allow_null = FALSE) {
     if (allow_null && is.null(x)) return(NULL)
     if (!is.numeric(x) || length(x) != 1L || !is.finite(x) ||
@@ -126,7 +126,7 @@ NNS.stack <- function(IVs.train,
     }
     as.integer(x)
   }
-  
+
   .as_train_frame <- function(x) {
     if (any(class(x) %in% c("tbl", "data.table"))) x <- as.data.frame(x)
     if (is.null(dim(x))) x <- data.frame(X1 = x, check.names = FALSE)
@@ -142,17 +142,17 @@ NNS.stack <- function(IVs.train,
     }
     x
   }
-  
+
   .as_test_frame <- function(x, train_names) {
     p <- length(train_names)
     had_names <- !is.null(dim(x)) && !is.null(colnames(x)) &&
       length(colnames(x)) == NCOL(x) && all(colnames(x) != "")
-    
+
     if (any(class(x) %in% c("tbl", "data.table"))) {
       had_names <- !is.null(names(x)) && all(names(x) != "")
       x <- as.data.frame(x)
     }
-    
+
     if (is.null(dim(x))) {
       if (p == 1L) {
         x <- data.frame(x, check.names = FALSE)
@@ -181,12 +181,12 @@ NNS.stack <- function(IVs.train,
     } else {
       x <- as.data.frame(x, check.names = FALSE, stringsAsFactors = FALSE)
     }
-    
+
     if (ncol(x) != p) {
       stop("[IVs.test] must have the same number of predictors as [IVs.train].",
            call. = FALSE)
     }
-    
+
     if (!had_names) {
       names(x) <- train_names
     } else {
@@ -205,16 +205,16 @@ NNS.stack <- function(IVs.train,
       }
       x <- x[, train_names, drop = FALSE]
     }
-    
+
     x
   }
-  
+
   .align_predictors <- function(train, test) {
     for (j in seq_along(train)) {
       nm <- names(train)[j]
       tr <- train[[j]]
       te <- test[[j]]
-      
+
       if (inherits(tr, "Date")) {
         if (!inherits(te, "Date")) {
           stop(sprintf("Test predictor [%s] must also be a Date.", nm),
@@ -261,7 +261,7 @@ NNS.stack <- function(IVs.train,
     }
     list(train = train, test = test)
   }
-  
+
   .check_predictors <- function(x, name) {
     if (anyNA(x)) stop(sprintf("[%s] contains missing values.", name), call. = FALSE)
     for (j in seq_along(x)) {
@@ -271,7 +271,7 @@ NNS.stack <- function(IVs.train,
       }
     }
   }
-  
+
   .restore_rng <- local({
     existed <- exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
     old <- if (existed) get(".Random.seed", envir = .GlobalEnv,
@@ -286,7 +286,7 @@ NNS.stack <- function(IVs.train,
     }
   })
   on.exit(.restore_rng(), add = TRUE)
-  
+
   optimize.threshold <- .scalar_logical(optimize.threshold, "optimize.threshold")
   balance <- .scalar_logical(balance, "balance")
   stack <- .scalar_logical(stack, "stack")
@@ -294,31 +294,31 @@ NNS.stack <- function(IVs.train,
   folds <- .scalar_integer(folds, "folds", minimum = 1L)
   ts.test <- .scalar_integer(ts.test, "ts.test", minimum = 1L,
                              allow_null = TRUE)
-  
+
   if (!is.null(seed)) {
     seed <- .scalar_integer(seed, "seed", minimum = 0L)
     set.seed(seed)
   }
-  
+
   if (is.null(obj.fn) || !(is.expression(obj.fn) || is.call(obj.fn))) {
     stop("[obj.fn] must be a non-NULL expression or call.", call. = FALSE)
   }
   if (is.expression(obj.fn) && length(obj.fn) != 1L) {
     stop("[obj.fn] must contain exactly one expression.", call. = FALSE)
   }
-  
+
   if (!is.character(objective) || length(objective) != 1L || is.na(objective)) {
     stop("[objective] must be exactly 'min' or 'max'.", call. = FALSE)
   }
   objective <- match.arg(tolower(objective), c("min", "max"))
-  
+
   if (!is.null(type)) {
     if (!is.character(type) || length(type) != 1L || is.na(type)) {
       stop("[type] must be NULL or 'CLASS'.", call. = FALSE)
     }
     type <- match.arg(tolower(type), "class")
   }
-  
+
   if (!is.null(order)) {
     if (is.character(order)) {
       if (length(order) != 1L || tolower(order) != "max") {
@@ -330,7 +330,7 @@ NNS.stack <- function(IVs.train,
       order <- .scalar_integer(order, "order", minimum = 1L)
     }
   }
-  
+
   if (!is.numeric(method) || !length(method) || any(!is.finite(method)) ||
       any(method != floor(method))) {
     stop("[method] must contain only 1 and/or 2.", call. = FALSE)
@@ -339,7 +339,7 @@ NNS.stack <- function(IVs.train,
   if (!all(method %in% c(1L, 2L))) {
     stop("[method] must contain only 1 and/or 2.", call. = FALSE)
   }
-  
+
   if (!is.null(CV.size)) {
     if (!is.numeric(CV.size) || length(CV.size) != 1L ||
         !is.finite(CV.size) || CV.size <= 0 || CV.size >= 1) {
@@ -348,7 +348,7 @@ NNS.stack <- function(IVs.train,
     }
     CV.size <- as.numeric(CV.size)
   }
-  
+
   if (!is.null(pred.int)) {
     if (!is.numeric(pred.int) || length(pred.int) != 1L ||
         !is.finite(pred.int) || pred.int <= 0 || pred.int >= 1) {
@@ -357,7 +357,7 @@ NNS.stack <- function(IVs.train,
     }
     pred.int <- as.numeric(pred.int)
   }
-  
+
   if (is.null(ncores)) {
     detected <- suppressWarnings(parallel::detectCores())
     if (!is.finite(detected)) detected <- 2L
@@ -365,7 +365,7 @@ NNS.stack <- function(IVs.train,
   } else {
     ncores <- .scalar_integer(ncores, "ncores", minimum = 1L)
   }
-  
+
   if (!is.character(dist) || length(dist) != 1L || is.na(dist)) {
     stop("[dist] must be one character value.", call. = FALSE)
   }
@@ -379,13 +379,13 @@ NNS.stack <- function(IVs.train,
     ), call. = FALSE)
   }
   dist <- "L2"
-  
+
   # -------------------------------------------------------------------------
   # Input data and response coding
   # -------------------------------------------------------------------------
-  
+
   x <- .as_train_frame(IVs.train)
-  
+
   if (any(class(DV.train) %in% c("tbl", "data.table"))) {
     DV.train <- as.vector(unlist(DV.train))
   }
@@ -396,7 +396,7 @@ NNS.stack <- function(IVs.train,
     }
     DV.train <- as.vector(unlist(DV.train))
   }
-  
+
   if (length(DV.train) != nrow(x)) {
     stop("nrow(IVs.train) must equal length(DV.train).", call. = FALSE)
   }
@@ -411,27 +411,27 @@ NNS.stack <- function(IVs.train,
       any(!is.finite(DV.train))) {
     stop("[DV.train] contains non-finite values.", call. = FALSE)
   }
-  
+
   response_was_factor <- is.factor(DV.train)
   response_was_ordered <- is.ordered(DV.train)
   response_was_character <- is.character(DV.train)
   response_was_logical <- is.logical(DV.train)
   response_was_numeric <- is.numeric(DV.train) || is.integer(DV.train)
-  
+
   auto_class <- response_was_factor || response_was_character ||
     response_was_logical ||
     (response_was_numeric && length(unique(DV.train)) == 2L)
-  
+
   if (auto_class && is.null(type)) type <- "class"
   if (balance && is.null(type)) {
     warning("type = 'CLASS' selected because balance = TRUE.", call. = FALSE)
     type <- "class"
   }
   is_class <- identical(type, "class")
-  
+
   original_response <- DV.train
   class_values <- NULL
-  
+
   if (is_class) {
     if (response_was_factor) {
       response_factor <- droplevels(DV.train)
@@ -449,7 +449,7 @@ NNS.stack <- function(IVs.train,
     } else {
       stop("Unsupported classification response type.", call. = FALSE)
     }
-    
+
     y <- as.numeric(y)
     if (length(unique(y)) < 2L) {
       stop("Classification requires at least two response classes.",
@@ -459,7 +459,7 @@ NNS.stack <- function(IVs.train,
       stop("Each response class requires at least two observations for cross-validation.",
            call. = FALSE)
     }
-    
+
     if (identical(obj.fn, expression(sum((predicted - actual)^2)))) {
       obj.fn <- expression(mean(predicted == actual))
       objective <- "max"
@@ -470,38 +470,38 @@ NNS.stack <- function(IVs.train,
     }
     y <- as.numeric(DV.train)
   }
-  
+
   if (balance && !is_class) {
     stop("[balance = TRUE] requires classification.", call. = FALSE)
   }
-  
+
   if (is.null(IVs.test)) {
     z <- x
   } else {
     z <- .as_test_frame(IVs.test, names(x))
   }
-  
+
   aligned <- .align_predictors(x, z)
   x <- aligned$train
   z <- aligned$test
   .check_predictors(x, "IVs.train")
   .check_predictors(z, "IVs.test")
-  
+
   n_obs <- nrow(x)
   original_p <- ncol(x)
-  
+
   if (!is.null(ts.test) && ts.test >= n_obs) {
     stop("[ts.test] must be smaller than the number of training observations.",
          call. = FALSE)
   }
-  
+
   if (original_p == 1L && 2L %in% method) {
     warning("Method 2 was removed because dimension reduction requires more than one original predictor.",
             call. = FALSE)
     method <- setdiff(method, 2L)
     if (!length(method)) method <- 1L
   }
-  
+
   if (2L %in% method) {
     if (is.numeric(dim.red.method)) {
       if (!length(dim.red.method) || any(!is.finite(dim.red.method))) {
@@ -520,18 +520,18 @@ NNS.stack <- function(IVs.train,
       )
     }
   }
-  
+
   # Add a constant non-integer translation to every fitting response. This keeps
   # NNS.reg from silently auto-switching integer-valued regression or class-code
   # targets into its internal classification path. Predictions and intervals are
   # translated back before scoring or returning.
   response_offset <- 0.123456789
   y_fit_all <- y + response_offset
-  
+
   # -------------------------------------------------------------------------
   # Shared helpers
   # -------------------------------------------------------------------------
-  
+
   .score <- function(predicted, actual) {
     if (length(predicted) != length(actual)) {
       stop("The objective received predicted and actual vectors of different lengths.",
@@ -547,7 +547,7 @@ NNS.stack <- function(IVs.train,
     if (!is.finite(value)) return(NA_real_)
     value
   }
-  
+
   .sanitize_raw <- function(predicted, fallback_y) {
     predicted <- as.numeric(predicted)
     bad <- !is.finite(predicted)
@@ -562,7 +562,7 @@ NNS.stack <- function(IVs.train,
     }
     predicted
   }
-  
+
   .round_codes <- function(raw, threshold) {
     raw <- pmin(pmax(as.numeric(raw), 1), length(class_values))
     lo <- floor(raw)
@@ -571,7 +571,7 @@ NNS.stack <- function(IVs.train,
     out <- ifelse(frac < threshold, lo, hi)
     as.integer(pmin(pmax(out, 1L), length(class_values)))
   }
-  
+
   .best_threshold <- function(raw, actual) {
     if (!is_class || !optimize.threshold) return(0.5)
     grid <- seq(0.01, 0.99, by = 0.01)
@@ -588,20 +588,20 @@ NNS.stack <- function(IVs.train,
     tied <- valid[scores[valid] == best_value]
     grid[tied[ceiling(length(tied) / 2)]]
   }
-  
+
   .evaluate_raw <- function(raw, actual) {
     threshold <- if (is_class) .best_threshold(raw, actual) else 0.5
     predicted <- if (is_class) .round_codes(raw, threshold) else raw
     list(score = .score(predicted, actual), threshold = threshold)
   }
-  
+
   # Preserve the historical NNS.stack classification contract: predictions
   # are numeric factor codes 1, ..., K. The original labels remain available in
   # result$class.levels, so code j maps to result$class.levels[j].
   .decode_codes <- function(code) {
     as.numeric(as.integer(pmin(pmax(code, 1L), length(class_values))))
   }
-  
+
   .decode_interval <- function(interval, threshold) {
     if (is.null(interval)) return(NULL)
     interval <- as.data.frame(interval, check.names = FALSE)
@@ -610,18 +610,18 @@ NNS.stack <- function(IVs.train,
     })
     interval
   }
-  
+
   .translate_interval <- function(interval) {
     if (is.null(interval)) return(NULL)
     interval <- as.data.frame(interval, check.names = FALSE)
     interval[] <- lapply(interval, function(v) as.numeric(v) - response_offset)
     interval
   }
-  
+
   .has_all_classes <- function(train_y) {
     !is_class || identical(sort(unique(train_y)), sort(unique(y)))
   }
-  
+
   .balance_indices <- function(train_y) {
     if (!balance) return(seq_along(train_y))
     groups <- split(seq_along(train_y), train_y)
@@ -639,16 +639,16 @@ NNS.stack <- function(IVs.train,
     }), use.names = FALSE)
     sample(c(down_idx, up_idx), replace = FALSE)
   }
-  
+
   .numeric_design <- function(train, test) {
     train_blocks <- vector("list", ncol(train))
     test_blocks <- vector("list", ncol(train))
-    
+
     for (j in seq_along(train)) {
       nm <- names(train)[j]
       tr <- train[[j]]
       te <- test[[j]]
-      
+
       if (is.factor(tr)) {
         lev <- levels(tr)
         tr_chr <- as.character(tr)
@@ -670,38 +670,38 @@ NNS.stack <- function(IVs.train,
         te_block <- matrix(as.numeric(te), ncol = 1L,
                            dimnames = list(NULL, nm))
       }
-      
+
       train_blocks[[j]] <- tr_block
       test_blocks[[j]] <- te_block
     }
-    
+
     train_matrix <- do.call(cbind, train_blocks)
     test_matrix <- do.call(cbind, test_blocks)
     storage.mode(train_matrix) <- "double"
     storage.mode(test_matrix) <- "double"
     colnames(train_matrix) <- make.unique(colnames(train_matrix), sep = "_")
     colnames(test_matrix) <- colnames(train_matrix)
-    
+
     train_min <- apply(train_matrix, 2L, min)
     train_max <- apply(train_matrix, 2L, max)
     train_range <- train_max - train_min
     train_range[!is.finite(train_range) | train_range == 0] <- 1
-    
+
     train_scaled <- sweep(train_matrix, 2L, train_min, "-")
     train_scaled <- sweep(train_scaled, 2L, train_range, "/")
     test_scaled <- sweep(test_matrix, 2L, train_min, "-")
     test_scaled <- sweep(test_scaled, 2L, train_range, "/")
-    
+
     train_scaled <- as.data.frame(train_scaled, check.names = FALSE)
     test_scaled <- as.data.frame(test_scaled, check.names = FALSE)
-    
+
     list(train = train_scaled, test = test_scaled,
          minimum = train_min, range = train_range)
   }
-  
+
   .make_splits <- function() {
     all_index <- seq_len(n_obs)
-    
+
     if (!is.null(ts.test)) {
       possible <- floor((n_obs - 1L) / ts.test)
       if (possible < 1L) {
@@ -733,7 +733,7 @@ NNS.stack <- function(IVs.train,
       }
       return(out)
     }
-    
+
     # Historical compatibility: folds = 1 means one repeated holdout even when
     # CV.size is omitted. The original implementation drew a validation
     # fraction between 0.20 and 1/3, so retain that behavior under the local
@@ -742,7 +742,7 @@ NNS.stack <- function(IVs.train,
     if (is.null(holdout_size) && folds == 1L) {
       holdout_size <- round(stats::runif(1L, 0.20, 1 / 3), 3L)
     }
-    
+
     if (!is.null(holdout_size)) {
       out <- vector("list", folds)
       for (b in seq_len(folds)) {
@@ -770,7 +770,7 @@ NNS.stack <- function(IVs.train,
       }
       return(out)
     }
-    
+
     use_folds <- min(folds, n_obs)
     if (is_class) {
       class_counts <- table(y)
@@ -788,7 +788,7 @@ NNS.stack <- function(IVs.train,
       warning(sprintf("Cross-validation folds reduced to %d for the available data.",
                       use_folds), call. = FALSE)
     }
-    
+
     fold_id <- integer(n_obs)
     if (is_class) {
       groups <- split(all_index, y)
@@ -800,7 +800,7 @@ NNS.stack <- function(IVs.train,
       shuffled <- sample(all_index, n_obs, replace = FALSE)
       fold_id[shuffled] <- rep(seq_len(use_folds), length.out = n_obs)
     }
-    
+
     out <- lapply(seq_len(use_folds), function(b) {
       validation <- which(fold_id == b)
       training <- setdiff(all_index, validation)
@@ -817,13 +817,13 @@ NNS.stack <- function(IVs.train,
     }
     out
   }
-  
+
   splits <- .make_splits()
-  
+
   .coefficient_vector <- function(X, response) {
     X <- as.matrix(X)
     p <- ncol(X)
-    
+
     if (is.numeric(dim.red.method)) {
       coef <- as.numeric(dim.red.method)
       if (!is.null(names(dim.red.method))) {
@@ -842,7 +842,7 @@ NNS.stack <- function(IVs.train,
       coef[!is.finite(coef)] <- 0
       return(coef)
     }
-    
+
     cor_coef <- function() {
       out <- vapply(seq_len(p), function(j) {
         suppressWarnings(stats::cor(X[, j], response, method = "spearman"))
@@ -850,7 +850,7 @@ NNS.stack <- function(IVs.train,
       out[!is.finite(out)] <- 0
       out
     }
-    
+
     dep_coef <- function() {
       out <- vapply(seq_len(p), function(j) {
         tryCatch(
@@ -862,7 +862,7 @@ NNS.stack <- function(IVs.train,
       out[!is.finite(out)] <- 0
       out
     }
-    
+
     caus_coef <- function() {
       tau_value <- if (is.null(ts.test)) "cs" else "ts"
       out <- vapply(seq_len(p), function(j) {
@@ -875,7 +875,7 @@ NNS.stack <- function(IVs.train,
       out[!is.finite(out)] <- 0
       out
     }
-    
+
     coef <- switch(
       dim.red.method,
       "cor" = cor_coef(),
@@ -885,16 +885,16 @@ NNS.stack <- function(IVs.train,
       "all" = rowMeans(cbind(caus_coef(), dep_coef(), cor_coef(), rep(1, p))),
       stop("Unsupported [dim.red.method].", call. = FALSE)
     )
-    
+
     coef[!is.finite(coef)] <- 0
     if (!any(abs(coef) > 0)) coef <- rep(1, p)
     coef
   }
-  
+
   .active_coefficients <- function(coef, count) {
     coef <- as.numeric(coef)
     count <- max(1L, min(as.integer(count), length(coef)))
-    ord <- order(abs(coef), decreasing = TRUE, na.last = NA)
+    ord <- order(abs(coef), decreasing = TRUE, na.last = NA, method = "radix")
     active <- ord[seq_len(min(count, length(ord)))]
     out <- rep(0, length(coef))
     out[active] <- coef[active]
@@ -903,7 +903,7 @@ NNS.stack <- function(IVs.train,
     }
     out
   }
-  
+
   .project_xstar <- function(train_design, test_design, coef) {
     denom <- sum(abs(coef) > 0)
     if (denom < 1L) stop("No active dimension-reduction coefficients.",
@@ -913,28 +913,44 @@ NNS.stack <- function(IVs.train,
       test = as.numeric(as.matrix(test_design) %*% coef / denom)
     )
   }
-  
+
+  .xstar_path <- function(train_design, test_design, coef) {
+    ord <- order(abs(coef), decreasing = TRUE, na.last = NA, method = "radix")
+    if (isTRUE(getOption("NNS.native.stack", TRUE))) {
+      tryCatch(NNS_xstar_path_cpp(as.matrix(train_design), as.matrix(test_design),
+                                  as.numeric(coef), as.integer(ord), as.integer(ncores)),
+               error = function(e) NULL)
+    } else NULL
+  }
+
   .fit_univariate_raw <- function(train_x, train_y_fit, test_x,
                                   confidence.interval = NULL,
                                   point.only = TRUE,
                                   allow_failure = FALSE) {
     fit <- tryCatch(
-      suppressWarnings(
-        NNS.reg(
-          as.numeric(train_x),
-          as.numeric(train_y_fit),
-          point.est = as.numeric(test_x),
-          plot = FALSE,
-          residual.plot = FALSE,
-          order = order,
-          type = NULL,
-          factor.2.dummy = FALSE,
-          dist = dist,
-          ncores = ncores,
-          point.only = point.only,
-          confidence.interval = confidence.interval
-        )
-      ),
+      suppressWarnings({
+        if (point.only && isTRUE(getOption("NNS.native.univariate", TRUE))) {
+          fast <- .nns_reg_univariate_fast(as.numeric(train_x), as.numeric(train_y_fit),
+                                           as.numeric(test_x), order = order,
+                                           noise.reduction = "off", is.class = FALSE)
+          list(Point.est = fast$prediction)
+        } else {
+          NNS.reg(
+            as.numeric(train_x),
+            as.numeric(train_y_fit),
+            point.est = as.numeric(test_x),
+            plot = FALSE,
+            residual.plot = FALSE,
+            order = order,
+            type = NULL,
+            factor.2.dummy = FALSE,
+            dist = dist,
+            ncores = ncores,
+            point.only = point.only,
+            confidence.interval = confidence.interval
+          )
+        }
+      }),
       error = function(e) {
         if (allow_failure) return(NULL)
         stop(e)
@@ -947,8 +963,8 @@ NNS.stack <- function(IVs.train,
                          train_y_fit - response_offset)
     list(raw = raw, fit = fit)
   }
-  
-  
+
+
   # Score every k with exactly the estimator the final NNS.reg fit uses:
   # NNS_mreg_predict_path_cpp implements the repaired multivariate prediction
   # rule (range-normalized metric, stable ties, ensemble weights) for
@@ -970,10 +986,18 @@ NNS.stack <- function(IVs.train,
     maximums <- vapply(train_design, max, numeric(1L))
     dist_code <- match(dist, c("L2", "L1", "FACTOR")) - 1L
 
-    path <- NNS_mreg_predict_path_cpp(
-      rpm_x, as.numeric(rpm$y.hat), test_matrix, as.integer(kmax),
-      dist_code, as.numeric(minimums), as.numeric(maximums), FALSE
-    )
+    path <- if (isTRUE(getOption("NNS.native.stack", TRUE))) {
+      NNS_mreg_predict_path_v2_cpp(
+        rpm_x, as.numeric(rpm$y.hat), test_matrix, as.integer(kmax),
+        dist_code, as.numeric(minimums), as.numeric(maximums), FALSE,
+        as.integer(ncores)
+      )
+    } else {
+      NNS_mreg_predict_path_cpp(
+        rpm_x, as.numeric(rpm$y.hat), test_matrix, as.integer(kmax),
+        dist_code, as.numeric(minimums), as.numeric(maximums), FALSE
+      )
+    }
     if (nrow(path) != nrow(test_matrix)) {
       stop("The production distance path returned an invalid row count.",
            call. = FALSE)
@@ -995,7 +1019,7 @@ NNS.stack <- function(IVs.train,
          threshold = evaluation$threshold,
          raw = raw)
   }
-  
+
   .select_best <- function(scores) {
     valid <- which(is.finite(scores))
     if (!length(valid)) {
@@ -1010,11 +1034,11 @@ NNS.stack <- function(IVs.train,
     tied <- valid[scores[valid] == best_value]
     as.integer(tied[ceiling(length(tied) / 2)])
   }
-  
+
   # Full-data encoded design establishes the fixed encoded column domain.
   full_design <- .numeric_design(x, z)
   encoded_p <- ncol(full_design$train)
-  
+
   if (2L %in% method && is.numeric(dim.red.method) &&
       is.null(names(dim.red.method)) && length(dim.red.method) != encoded_p) {
     stop(sprintf(
@@ -1022,11 +1046,11 @@ NNS.stack <- function(IVs.train,
       encoded_p
     ), call. = FALSE)
   }
-  
+
   # -------------------------------------------------------------------------
   # Method 2: select active dimension count from OOF predictions
   # -------------------------------------------------------------------------
-  
+
   dim_best_count <- NA_integer_
   dim_best_score <- NA_real_
   dim_component_threshold <- 0.5
@@ -1035,11 +1059,11 @@ NNS.stack <- function(IVs.train,
   dim_full_coef <- NULL
   dim_full_xstar_train <- NULL
   dim_full_xstar_test <- NULL
-  
+
   if (2L %in% method) {
     dim_sum <- matrix(0, nrow = n_obs, ncol = encoded_p)
     dim_count <- matrix(0L, nrow = n_obs, ncol = encoded_p)
-    
+
     for (b in seq_along(splits)) {
       split <- splits[[b]]
       train_idx <- split$train
@@ -1050,41 +1074,43 @@ NNS.stack <- function(IVs.train,
       )
       coef_fold <- .coefficient_vector(fold_design$train, y[train_idx])
       balanced_idx <- .balance_indices(y[train_idx])
-      
+
+      if (status) message(sprintf("Method 2 fold %d/%d: generating %d cumulative projections", b, length(splits), encoded_p))
+      native_path <- .xstar_path(fold_design$train, fold_design$test, coef_fold)
+      representatives <- if (!is.null(native_path)) as.integer(native_path$representative) else seq_len(encoded_p)
+      unique_candidates <- unique(representatives)
+      if (status) message(sprintf("Method 2 fold %d/%d: evaluating %d unique candidates", b, length(splits), length(unique_candidates)))
+      candidate_raw <- vector("list", encoded_p)
+      for (m in unique_candidates) {
+        if (!is.null(native_path)) {
+          projected <- list(train = native_path$train[, m], test = native_path$test[, m])
+        } else {
+          active_coef <- .active_coefficients(coef_fold, m)
+          projected <- .project_xstar(fold_design$train, fold_design$test, active_coef)
+        }
+        fit <- .fit_univariate_raw(projected$train[balanced_idx],
+                                   y_fit_all[train_idx][balanced_idx],
+                                   projected$test,
+                                   point.only = TRUE,
+                                   allow_failure = TRUE)
+        candidate_raw[[m]] <- fit$raw
+      }
       for (m in seq_len(encoded_p)) {
-        active_coef <- .active_coefficients(coef_fold, m)
-        projected <- .project_xstar(
-          fold_design$train,
-          fold_design$test,
-          active_coef
-        )
-        fit <- .fit_univariate_raw(
-          projected$train[balanced_idx],
-          y_fit_all[train_idx][balanced_idx],
-          projected$test,
-          point.only = TRUE,
-          allow_failure = TRUE
-        )
-        good <- is.finite(fit$raw)
+        raw <- candidate_raw[[representatives[m]]]
+        good <- is.finite(raw)
         if (any(good)) {
           rows <- valid_idx[good]
-          dim_sum[rows, m] <- dim_sum[rows, m] + fit$raw[good]
+          dim_sum[rows, m] <- dim_sum[rows, m] + raw[good]
           dim_count[rows, m] <- dim_count[rows, m] + 1L
         }
       }
-      
-      if (status) {
-        message(sprintf(
-          "Dimension-reduction folds remaining = %d",
-          length(splits) - b
-        ))
-      }
+      if (status) message(sprintf("Method 2 fold %d/%d complete", b, length(splits)))
     }
-    
+
     dim_scores <- rep(NA_real_, encoded_p)
     dim_thresholds <- rep(0.5, encoded_p)
     dim_raw_candidates <- vector("list", encoded_p)
-    
+
     for (m in seq_len(encoded_p)) {
       candidate <- .candidate_from_oof(dim_sum, dim_count, m)
       dim_scores[m] <- candidate$score
@@ -1101,23 +1127,30 @@ NNS.stack <- function(IVs.train,
         ))
       }
     }
-    
+
     dim_best_count <- .select_best(dim_scores)
     dim_best_score <- dim_scores[dim_best_count]
     dim_component_threshold <- dim_thresholds[dim_best_count]
     dim_oof_raw <- dim_raw_candidates[[dim_best_count]]
-    
+
     dim_full_coef_original <- .coefficient_vector(full_design$train, y)
     dim_full_coef <- .active_coefficients(dim_full_coef_original,
                                           dim_best_count)
-    dim_full_projection <- .project_xstar(
-      full_design$train,
-      full_design$test,
-      dim_full_coef
-    )
-    dim_full_xstar_train <- dim_full_projection$train
-    dim_full_xstar_test <- dim_full_projection$test
-    
+    dim_full_projection <- .xstar_path(full_design$train, full_design$test,
+                                       dim_full_coef)
+    if (is.null(dim_full_projection)) {
+      dim_full_projection <- .project_xstar(
+        full_design$train,
+        full_design$test,
+        dim_full_coef
+      )
+      dim_full_xstar_train <- dim_full_projection$train
+      dim_full_xstar_test <- dim_full_projection$test
+    } else {
+      dim_full_xstar_train <- dim_full_projection$train[, dim_best_count]
+      dim_full_xstar_test <- dim_full_projection$test[, dim_best_count]
+    }
+
     active_magnitudes <- abs(dim_full_coef[abs(dim_full_coef) > 0])
     dim_threshold_report <- if (dim_best_count >= length(dim_full_coef)) {
       0
@@ -1128,22 +1161,22 @@ NNS.stack <- function(IVs.train,
     }
     if (!is.finite(dim_threshold_report)) dim_threshold_report <- 0
   }
-  
+
   # -------------------------------------------------------------------------
   # Method 1: use production RPM and production distance path for every k
   # -------------------------------------------------------------------------
-  
+
   reg_best_k <- NA_integer_
   reg_best_score <- NA_real_
   reg_component_threshold <- 0.5
   reg_oof_raw <- rep(NA_real_, n_obs)
-  
+
   .method1_design_for_split <- function(train_idx, valid_idx) {
     fold_design <- .numeric_design(
       x[train_idx, , drop = FALSE],
       x[valid_idx, , drop = FALSE]
     )
-    
+
     if (stack && 2L %in% method) {
       coef_fold <- .coefficient_vector(fold_design$train, y[train_idx])
       active_coef <- .active_coefficients(coef_fold, dim_best_count)
@@ -1164,21 +1197,22 @@ NNS.stack <- function(IVs.train,
       list(train = fold_design$train, test = fold_design$test)
     }
   }
-  
+
   if (1L %in% method) {
     fold_paths <- vector("list", length(splits))
     fold_kmax <- integer(length(splits))
-    
+
     for (b in seq_along(splits)) {
       split <- splits[[b]]
       train_idx <- split$train
       valid_idx <- split$validation
+      if (status) message(sprintf("Method 1 fold %d/%d: preparing fold design", b, length(splits)))
       design <- .method1_design_for_split(train_idx, valid_idx)
       balanced_idx <- .balance_indices(y[train_idx])
       train_design <- design$train[balanced_idx, , drop = FALSE]
       train_y_fit <- y_fit_all[train_idx][balanced_idx]
       valid_design <- design$test
-      
+
       if (ncol(train_design) == 1L) {
         direct <- .fit_univariate_raw(
           train_design[[1L]],
@@ -1189,58 +1223,38 @@ NNS.stack <- function(IVs.train,
         )
         path <- matrix(direct$raw, ncol = 1L)
       } else {
-        setup <- suppressWarnings(
-          NNS.reg(
-            train_design,
-            train_y_fit,
-            point.est = NULL,
-            plot = FALSE,
-            residual.plot = FALSE,
-            order = order,
-            type = NULL,
-            factor.2.dummy = FALSE,
-            dist = dist,
-            ncores = ncores,
-            point.only = FALSE
-          )
-        )
-        
+        if (status) message(sprintf("Method 1 fold %d/%d: building partitions", b, length(splits)))
+        setup <- .nns_mreg_prepare_model(train_design, train_y_fit, order = order,
+                                         noise.reduction = "off", is.class = FALSE,
+                                         use.native = isTRUE(getOption("NNS.native.mreg", TRUE)))
         rpm <- setup$RPM
-        if (is.null(rpm) || !is.data.frame(rpm) || nrow(rpm) < 1L ||
-            !"y.hat" %in% names(rpm)) {
-          stop("NNS.reg did not return a usable regression-point matrix.",
-               call. = FALSE)
+        if (is.null(rpm) || !is.data.frame(rpm) || nrow(rpm) < 1L || !"y.hat" %in% names(rpm)) {
+          stop("NNS.reg did not return a usable regression-point matrix.", call. = FALSE)
         }
-        
-        path <- .production_multivariate_path(
-          rpm = rpm,
-          Xtest = valid_design,
-          train_design = train_design
-        )
+        if (status) message(sprintf("Method 1 fold %d/%d: RPM rows = %d; validation rows = %d", b, length(splits), nrow(rpm), length(valid_idx)))
+        if (status) message(sprintf("Method 1 fold %d/%d: evaluating k = 1...%d", b, length(splits), nrow(rpm)))
+        path <- .production_multivariate_path(rpm = rpm, Xtest = valid_design, train_design = train_design)
         path <- path - response_offset
         for (k in seq_len(ncol(path))) {
           path[, k] <- .sanitize_raw(path[, k], y[train_idx])
         }
       }
-      
+
       fold_paths[[b]] <- list(path = path, validation = valid_idx)
       fold_kmax[b] <- ncol(path)
-      
-      if (status) {
-        message(sprintf("Method 1 folds remaining = %d",
-                        length(splits) - b))
-      }
+
+      if (status) message(sprintf("Method 1 fold %d/%d complete", b, length(splits)))
     }
-    
+
     common_kmax <- min(fold_kmax)
     if (!is.finite(common_kmax) || common_kmax < 1L) {
       stop("No common n.best candidate was available across folds.",
            call. = FALSE)
     }
-    
+
     reg_sum <- matrix(0, nrow = n_obs, ncol = common_kmax)
     reg_count <- matrix(0L, nrow = n_obs, ncol = common_kmax)
-    
+
     for (b in seq_along(fold_paths)) {
       valid_idx <- fold_paths[[b]]$validation
       path <- fold_paths[[b]]$path[, seq_len(common_kmax), drop = FALSE]
@@ -1253,11 +1267,11 @@ NNS.stack <- function(IVs.train,
         }
       }
     }
-    
+
     reg_scores <- rep(NA_real_, common_kmax)
     reg_thresholds <- rep(0.5, common_kmax)
     reg_raw_candidates <- vector("list", common_kmax)
-    
+
     for (k in seq_len(common_kmax)) {
       candidate <- .candidate_from_oof(reg_sum, reg_count, k)
       reg_scores[k] <- candidate$score
@@ -1274,20 +1288,20 @@ NNS.stack <- function(IVs.train,
         ))
       }
     }
-    
+
     reg_best_k <- .select_best(reg_scores)
     reg_best_score <- reg_scores[reg_best_k]
     reg_component_threshold <- reg_thresholds[reg_best_k]
     reg_oof_raw <- reg_raw_candidates[[reg_best_k]]
   }
-  
+
   # -------------------------------------------------------------------------
   # Optimize the actual OOF blend and its final classification threshold
   # -------------------------------------------------------------------------
-  
+
   component_weights <- c(reg = 0, dim.red = 0)
   probability.threshold <- if (is_class) 0.5 else 0.5
-  
+
   if (identical(method, 1L)) {
     component_weights["reg"] <- 1
     probability.threshold <- reg_component_threshold
@@ -1300,11 +1314,11 @@ NNS.stack <- function(IVs.train,
       stop("The two component models have no common finite OOF predictions.",
            call. = FALSE)
     }
-    
+
     weight_grid <- seq(0, 1, by = 0.01)
     blend_scores <- rep(NA_real_, length(weight_grid))
     blend_thresholds <- rep(0.5, length(weight_grid))
-    
+
     for (i in seq_along(weight_grid)) {
       w <- weight_grid[i]
       raw <- w * reg_oof_raw[valid] + (1 - w) * dim_oof_raw[valid]
@@ -1312,7 +1326,7 @@ NNS.stack <- function(IVs.train,
       blend_scores[i] <- evaluation$score
       blend_thresholds[i] <- evaluation$threshold
     }
-    
+
     valid_grid <- which(is.finite(blend_scores))
     if (!length(valid_grid)) {
       stop("No ensemble weight produced a finite OOF objective.",
@@ -1326,23 +1340,23 @@ NNS.stack <- function(IVs.train,
     tied <- valid_grid[blend_scores[valid_grid] == best_value]
     selected_index <- as.integer(tied[ceiling(length(tied) / 2)])
     selected_weight <- weight_grid[selected_index]
-    
+
     component_weights <- c(reg = selected_weight,
                            dim.red = 1 - selected_weight)
     probability.threshold <- blend_thresholds[selected_index]
   }
-  
+
   # -------------------------------------------------------------------------
   # Final production fits on complete training data
   # -------------------------------------------------------------------------
-  
+
   if (status) message("Generating final estimates")
-  
+
   reg_raw_final <- NULL
   reg_pred_int_raw <- NULL
   dim_raw_final <- NULL
   dim_pred_int_raw <- NULL
-  
+
   if (2L %in% method) {
     balanced_idx <- .balance_indices(y)
     dim_final_fit <- .fit_univariate_raw(
@@ -1355,7 +1369,7 @@ NNS.stack <- function(IVs.train,
     dim_raw_final <- dim_final_fit$raw
     dim_pred_int_raw <- .translate_interval(dim_final_fit$fit$pred.int)
   }
-  
+
   .method1_full_design <- function() {
     if (stack && 2L %in% method) {
       list(
@@ -1370,14 +1384,14 @@ NNS.stack <- function(IVs.train,
       list(train = full_design$train, test = full_design$test)
     }
   }
-  
+
   if (1L %in% method) {
     final_design <- .method1_full_design()
     balanced_idx <- .balance_indices(y)
     train_design <- final_design$train[balanced_idx, , drop = FALSE]
     train_y_fit <- y_fit_all[balanced_idx]
     test_design <- final_design$test
-    
+
     if (ncol(train_design) == 1L) {
       reg_final_fit <- .fit_univariate_raw(
         train_design[[1L]],
@@ -1413,7 +1427,7 @@ NNS.stack <- function(IVs.train,
       reg_pred_int_raw <- .translate_interval(reg_final_fit$pred.int)
     }
   }
-  
+
   # Component predictions retain their own OOF-optimized thresholds. The stack
   # uses the threshold optimized directly on the OOF weighted ensemble.
   if (is_class) {
@@ -1431,7 +1445,7 @@ NNS.stack <- function(IVs.train,
     reg_output <- if (!is.null(reg_raw_final)) reg_raw_final else NA_real_
     dim_output <- if (!is.null(dim_raw_final)) dim_raw_final else NA_real_
   }
-  
+
   if (identical(method, 1L)) {
     stacked_raw <- reg_raw_final
   } else if (identical(method, 2L)) {
@@ -1452,13 +1466,13 @@ NNS.stack <- function(IVs.train,
     stacked_raw <- component_weights["reg"] * reg_use +
       component_weights["dim.red"] * dim_use
   }
-  
+
   stacked_output <- if (is_class) {
     .decode_codes(.round_codes(stacked_raw, probability.threshold))
   } else {
     stacked_raw
   }
-  
+
   reg_pred_int <- if (is_class) {
     .decode_interval(reg_pred_int_raw, reg_component_threshold)
   } else {
@@ -1469,7 +1483,7 @@ NNS.stack <- function(IVs.train,
   } else {
     dim_pred_int_raw
   }
-  
+
   if (is.null(pred.int)) {
     stacked_pred_int_raw <- NULL
   } else if (identical(method, 1L)) {
@@ -1494,13 +1508,13 @@ NNS.stack <- function(IVs.train,
     )
     names(stacked_pred_int_raw) <- names(reg_pi)
   }
-  
+
   stacked_pred_int <- if (is_class) {
     .decode_interval(stacked_pred_int_raw, probability.threshold)
   } else {
     stacked_pred_int_raw
   }
-  
+
   result <- list(
     OBJfn.reg = reg_best_score,
     NNS.reg.n.best = reg_best_k,
@@ -1516,6 +1530,6 @@ NNS.stack <- function(IVs.train,
     weights = component_weights,
     class.levels = if (is_class) class_values else NULL
   )
-  
+
   .NNS.out(result)
 }

--- a/benchmarks/benchmark_stack_native.R
+++ b/benchmarks/benchmark_stack_native.R
@@ -1,0 +1,12 @@
+# Benchmark harness for corrected reference vs native stack paths.
+# Run from package root after devtools::load_all().
+library(NNS)
+run_case <- function(native) {
+  options(NNS.native.stack = native, NNS.native.mreg = native, NNS.native.univariate = native)
+  set.seed(123); x <- data.frame(a = rnorm(150), b = rnorm(150), c = rnorm(150)); y <- x$a + sin(x$b) - x$c^2
+  t <- system.time(fit <- NNS.stack(x, y, IVs.test = x[1:25,], method = 1, folds = 3, ncores = 1, status = FALSE))
+  data.frame(version = if (native) "native" else "reference", elapsed = unname(t["elapsed"]), nbest = fit$NNS.reg.n.best, checksum = sum(as.numeric(fit$stack)))
+}
+res <- rbind(run_case(FALSE), run_case(TRUE))
+write.csv(res, "benchmarks/stack_native_results.csv", row.names = FALSE)
+print(res)

--- a/benchmarks/stack_baseline_report.md
+++ b/benchmarks/stack_baseline_report.md
@@ -1,0 +1,3 @@
+# Stack baseline report
+
+R is not installed in this execution container, so this file provides the checked-in baseline schema and the benchmark harness records machine-local results when run in a complete R environment.

--- a/benchmarks/stack_baseline_results.csv
+++ b/benchmarks/stack_baseline_results.csv
@@ -1,0 +1,3 @@
+version,elapsed,median,minimum,memory,peak_memory,selected_model,n_best,dimension_count,objective,prediction_checksum
+reference,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+pre_repair,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/benchmarks/stack_native_report.md
+++ b/benchmarks/stack_native_report.md
@@ -1,0 +1,3 @@
+# Stack native report
+
+Run `Rscript benchmarks/benchmark_stack_native.R` after `devtools::load_all()` to populate `stack_native_results.csv` on an R-capable host.

--- a/benchmarks/stack_native_results.csv
+++ b/benchmarks/stack_native_results.csv
@@ -1,0 +1,2 @@
+version,elapsed,median,minimum,memory,peak_memory,selected_model,n_best,dimension_count,objective,prediction_checksum
+native,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/src/NNS_mreg_predict.cpp
+++ b/src/NNS_mreg_predict.cpp
@@ -214,9 +214,87 @@ inline void active_columns(const NumericVector& mins, const NumericVector& maxs,
 
 }  // namespace
 
-// Prediction path for every k = 1..kmax under the same rule as
-// NNS_mreg_predict_cpp, so cross-validated n.best selection scores exactly
-// the estimator the final NNS.reg fit will use.
+
+inline void rank_components(int k, std::vector<double>& uniform,
+                            std::vector<double>& exponential,
+                            std::vector<double>& lognormal,
+                            std::vector<double>& power) {
+  uniform.assign(k, 1.0 / static_cast<double>(k));
+  exponential.resize(k); lognormal.assign(k, 0.0); power.resize(k);
+  const double kk = static_cast<double>(k);
+  for (int i = 0; i < k; ++i) exponential[i] = ::Rf_dexp(static_cast<double>(i + 1), kk, 0);
+  normalize_weights(exponential);
+  std::vector<double> ranks(k);
+  for (int i = 0; i < k; ++i) ranks[i] = static_cast<double>(i + 1);
+  const double rank_sd = sample_sd(ranks);
+  if (R_finite(rank_sd) && rank_sd > 0.0) {
+    for (int i = 0; i < k; ++i) lognormal[i] = std::fabs(::Rf_dlnorm(ranks[i], 0.0, rank_sd, 1));
+    normalize_weights(lognormal);
+    std::reverse(lognormal.begin(), lognormal.end());
+  }
+  for (int i = 0; i < k; ++i) { const double r = static_cast<double>(i + 1); power[i] = 1.0 / (r * r); }
+  normalize_weights(power);
+}
+
+inline double predict_sorted_k(const std::vector<double>& dk, const std::vector<double>& yk,
+                               int k, bool is_class,
+                               const std::vector<double>& uniform,
+                               const std::vector<double>& exponential,
+                               const std::vector<double>& lognormal,
+                               const std::vector<double>& power) {
+  std::vector<double> student(k), inverse(k), normal(k, 0.0), rbf(k, 0.0), total(k);
+  for (int i = 0; i < k; ++i) student[i] = ::Rf_dt(dk[i], static_cast<double>(k), 0);
+  normalize_weights(student);
+  for (int i = 0; i < k; ++i) inverse[i] = 1.0 / std::max(dk[i], 1e-12);
+  normalize_weights(inverse);
+  double mu = 0.0; for (int i = 0; i < k; ++i) mu += dk[i]; mu /= static_cast<double>(k);
+  double acc = 0.0; for (int i = 0; i < k; ++i) { double z = dk[i] - mu; acc += z*z; }
+  const double sd = (k > 1) ? std::sqrt(acc / static_cast<double>(k - 1)) : NA_REAL;
+  const double var = (R_finite(sd)) ? sd * sd : NA_REAL;
+  if (R_finite(sd) && sd > 0.0) { for (int i = 0; i < k; ++i) normal[i] = ::Rf_dnorm4(dk[i], 0.0, sd, 0); normalize_weights(normal); }
+  if (R_finite(var) && var > 0.0) { for (int i = 0; i < k; ++i) rbf[i] = std::exp(-dk[i] / (2.0 * var)); normalize_weights(rbf); }
+  for (int i = 0; i < k; ++i) total[i] = uniform[i] + student[i] + inverse[i] + exponential[i] + lognormal[i] + power[i] + normal[i] + rbf[i];
+  normalize_weights(total);
+  if (is_class) {
+    std::vector<double> yy(yk.begin(), yk.begin() + k);
+    return weighted_mode(yy, total);
+  }
+  double dot = 0.0; for (int i = 0; i < k; ++i) dot += yk[i] * total[i];
+  return dot;
+}
+
+// [[Rcpp::export]]
+NumericMatrix NNS_mreg_predict_path_v2_cpp(const NumericMatrix& rpm_x,
+                                           const NumericVector& yhat,
+                                           const NumericMatrix& Xtest,
+                                           int kmax,
+                                           int dist_code,
+                                           const NumericVector& mins,
+                                           const NumericVector& maxs,
+                                           bool is_class,
+                                           int nthreads) {
+  const int n = rpm_x.nrow(), p = rpm_x.ncol(), m = Xtest.nrow();
+  if (yhat.size() != n) stop("yhat length must equal nrow(rpm_x)");
+  if (Xtest.ncol() != p) stop("Xtest and rpm_x must have the same columns");
+  if (mins.size() != p || maxs.size() != p) stop("mins/maxs must have one value per column");
+  if (kmax < 1) stop("kmax must be >= 1");
+  if (kmax > n) kmax = n;
+  std::vector<int> active; std::vector<double> inv_range; active_columns(mins, maxs, active, inv_range);
+  std::vector< std::vector<double> > U(kmax+1), E(kmax+1), L(kmax+1), P(kmax+1);
+  for (int k=2; k<=kmax; ++k) rank_components(k, U[k], E[k], L[k], P[k]);
+  NumericMatrix out(m, kmax);
+  std::vector<double> d(n), dk(kmax), yk(kmax); std::vector<int> idx(n);
+  for (int r = 0; r < m; ++r) {
+    row_distances(rpm_x, Xtest, r, dist_code, active, inv_range, d);
+    for (int i = 0; i < n; ++i) idx[i] = i;
+    std::stable_sort(idx.begin(), idx.end(), [&d](int a, int b) { return d[a] < d[b]; });
+    for (int i = 0; i < kmax; ++i) { dk[i] = d[idx[i]]; yk[i] = yhat[idx[i]]; }
+    out(r,0) = aggregate_min_ties(d, yhat, is_class);
+    for (int k=2; k<=kmax; ++k) out(r,k-1) = predict_sorted_k(dk, yk, k, is_class, U[k], E[k], L[k], P[k]);
+  }
+  return out;
+}
+
 // [[Rcpp::export]]
 NumericMatrix NNS_mreg_predict_path_cpp(const NumericMatrix& rpm_x,
                                         const NumericVector& yhat,
@@ -226,49 +304,21 @@ NumericMatrix NNS_mreg_predict_path_cpp(const NumericMatrix& rpm_x,
                                         const NumericVector& mins,
                                         const NumericVector& maxs,
                                         bool is_class) {
-  const int n = rpm_x.nrow(), p = rpm_x.ncol(), m = Xtest.nrow();
-  if (yhat.size() != n) stop("yhat length must equal nrow(rpm_x)");
-  if (Xtest.ncol() != p) stop("Xtest and rpm_x must have the same columns");
-  if (mins.size() != p || maxs.size() != p) stop("mins/maxs must have one value per column");
-  if (kmax < 1) stop("kmax must be >= 1");
-  if (kmax > n) kmax = n;
+  return NNS_mreg_predict_path_v2_cpp(rpm_x, yhat, Xtest, kmax, dist_code, mins, maxs, is_class, 1);
+}
 
-  std::vector<int> active;
-  std::vector<double> inv_range;
-  active_columns(mins, maxs, active, inv_range);
-
-  NumericMatrix out(m, kmax);
-  std::vector<double> d(n);
-  std::vector<int> idx(n);
-
-  for (int r = 0; r < m; ++r) {
-    row_distances(rpm_x, Xtest, r, dist_code, active, inv_range, d);
-
-    for (int i = 0; i < n; ++i) idx[i] = i;
-    std::stable_sort(idx.begin(), idx.end(),
-                     [&d](int a, int b) { return d[a] < d[b]; });
-
-    std::vector<double> dk(kmax), yk(kmax);
-    for (int i = 0; i < kmax; ++i) {
-      dk[i] = d[idx[i]];
-      yk[i] = yhat[idx[i]];
-    }
-
-    out(r, 0) = aggregate_min_ties(d, yhat, is_class);
-    for (int k = 2; k <= kmax; ++k) {
-      const std::vector<double> dsub(dk.begin(), dk.begin() + k);
-      const std::vector<double> w = ensemble_weights(dsub);
-      if (is_class) {
-        const std::vector<double> ysub(yk.begin(), yk.begin() + k);
-        out(r, k - 1) = weighted_mode(ysub, w);
-      } else {
-        double dot = 0.0;
-        for (int i = 0; i < k; ++i) dot += yk[i] * w[i];
-        out(r, k - 1) = dot;
-      }
-    }
-  }
-  return out;
+// [[Rcpp::export]]
+NumericVector NNS_mreg_predict_v2_cpp(const NumericMatrix& rpm_x,
+                                      const NumericVector& yhat,
+                                      const NumericMatrix& Xtest,
+                                      int k,
+                                      int dist_code,
+                                      const NumericVector& mins,
+                                      const NumericVector& maxs,
+                                      bool is_class,
+                                      int nthreads) {
+  NumericMatrix path = NNS_mreg_predict_path_v2_cpp(rpm_x, yhat, Xtest, k, dist_code, mins, maxs, is_class, nthreads);
+  return path(_, k - 1);
 }
 
 // dist_code: 0 = L2, 1 = L1, 2 = FACTOR (Hamming over encoded columns).

--- a/src/NNS_mreg_predict.cpp
+++ b/src/NNS_mreg_predict.cpp
@@ -6,12 +6,14 @@
 //   - k > 1 uses the eight-component ensemble weights built from Rmath
 //     densities, matching the R helper term for term,
 //   - exact double-precision weighted class mode (max total, tie -> min value).
-// Serial by design: no global RcppParallel thread state is touched.
+// Row-parallel with a per-call thread count; no global RcppParallel thread state is touched.
 #include <Rcpp.h>
+#include <RcppParallel.h>
 #include <algorithm>
 #include <cmath>
 #include <vector>
 using namespace Rcpp;
+using namespace RcppParallel;
 
 // central_tendencies.cpp
 double gravity_value(std::vector<double> x, bool discrete);
@@ -236,32 +238,187 @@ inline void rank_components(int k, std::vector<double>& uniform,
   normalize_weights(power);
 }
 
-inline double predict_sorted_k(const std::vector<double>& dk, const std::vector<double>& yk,
-                               int k, bool is_class,
-                               const std::vector<double>& uniform,
-                               const std::vector<double>& exponential,
-                               const std::vector<double>& lognormal,
-                               const std::vector<double>& power) {
-  std::vector<double> student(k), inverse(k), normal(k, 0.0), rbf(k, 0.0), total(k);
-  for (int i = 0; i < k; ++i) student[i] = ::Rf_dt(dk[i], static_cast<double>(k), 0);
-  normalize_weights(student);
-  for (int i = 0; i < k; ++i) inverse[i] = 1.0 / std::max(dk[i], 1e-12);
-  normalize_weights(inverse);
-  double mu = 0.0; for (int i = 0; i < k; ++i) mu += dk[i]; mu /= static_cast<double>(k);
-  double acc = 0.0; for (int i = 0; i < k; ++i) { double z = dk[i] - mu; acc += z*z; }
-  const double sd = (k > 1) ? std::sqrt(acc / static_cast<double>(k - 1)) : NA_REAL;
-  const double var = (R_finite(sd)) ? sd * sd : NA_REAL;
-  if (R_finite(sd) && sd > 0.0) { for (int i = 0; i < k; ++i) normal[i] = ::Rf_dnorm4(dk[i], 0.0, sd, 0); normalize_weights(normal); }
-  if (R_finite(var) && var > 0.0) { for (int i = 0; i < k; ++i) rbf[i] = std::exp(-dk[i] / (2.0 * var)); normalize_weights(rbf); }
-  for (int i = 0; i < k; ++i) total[i] = uniform[i] + student[i] + inverse[i] + exponential[i] + lognormal[i] + power[i] + normal[i] + rbf[i];
-  normalize_weights(total);
-  if (is_class) {
-    std::vector<double> yy(yk.begin(), yk.begin() + k);
-    return weighted_mode(yy, total);
+struct RankComponents {
+  std::vector< std::vector<double> > uniform, exponential, lognormal, power;
+  explicit RankComponents(int kmax) : uniform(kmax + 1), exponential(kmax + 1),
+    lognormal(kmax + 1), power(kmax + 1) {
+    for (int k = 2; k <= kmax; ++k) rank_components(k, uniform[k], exponential[k], lognormal[k], power[k]);
   }
-  double dot = 0.0; for (int i = 0; i < k; ++i) dot += yk[i] * total[i];
+};
+
+inline void normalize_prefix(std::vector<double>& values, int k) {
+  double s = 0.0;
+  for (int i = 0; i < k; ++i) {
+    if (!R_finite(values[i]) || values[i] < 0.0) values[i] = 0.0;
+    s += values[i];
+  }
+  if (s <= 0.0) {
+    const double u = 1.0 / static_cast<double>(k);
+    for (int i = 0; i < k; ++i) values[i] = u;
+  } else {
+    for (int i = 0; i < k; ++i) values[i] /= s;
+  }
+}
+
+inline double weighted_mode_prefix(const std::vector<double>& yk,
+                                   const std::vector<double>& weights,
+                                   int k,
+                                   std::vector<double>& cls,
+                                   std::vector<double>& totals) {
+  int ncls = 0;
+  for (int i = 0; i < k; ++i) {
+    const double v = yk[i], w = weights[i];
+    if (!R_finite(v) || !R_finite(w) || w < 0.0) continue;
+    int pos = -1;
+    for (int c = 0; c < ncls; ++c) if (cls[c] == v) { pos = c; break; }
+    if (pos < 0) { pos = ncls++; cls[pos] = v; totals[pos] = 0.0; }
+    totals[pos] += w;
+  }
+  if (ncls == 0) return NA_REAL;
+  double best_val = cls[0], best_tot = totals[0];
+  for (int c = 1; c < ncls; ++c) {
+    if (totals[c] > best_tot || (totals[c] == best_tot && cls[c] < best_val)) {
+      best_tot = totals[c]; best_val = cls[c];
+    }
+  }
+  return best_val;
+}
+
+inline double predict_sorted_k_noalloc(const std::vector<double>& dk,
+                                       const std::vector<double>& yk,
+                                       int k, bool is_class,
+                                       const RankComponents& rank,
+                                       std::vector<double>& student,
+                                       std::vector<double>& inverse,
+                                       std::vector<double>& normal,
+                                       std::vector<double>& rbf,
+                                       std::vector<double>& total,
+                                       std::vector<double>& cls,
+                                       std::vector<double>& cls_totals) {
+  for (int i = 0; i < k; ++i) student[i] = ::Rf_dt(dk[i], static_cast<double>(k), 0);
+  normalize_prefix(student, k);
+  for (int i = 0; i < k; ++i) inverse[i] = 1.0 / std::max(dk[i], 1e-12);
+  normalize_prefix(inverse, k);
+
+  double mu = 0.0;
+  for (int i = 0; i < k; ++i) mu += dk[i];
+  mu /= static_cast<double>(k);
+  double acc = 0.0;
+  for (int i = 0; i < k; ++i) { const double z = dk[i] - mu; acc += z * z; }
+  const double sd = (k > 1) ? std::sqrt(acc / static_cast<double>(k - 1)) : NA_REAL;
+  const double var = R_finite(sd) ? sd * sd : NA_REAL;
+  if (R_finite(sd) && sd > 0.0) {
+    for (int i = 0; i < k; ++i) normal[i] = ::Rf_dnorm4(dk[i], 0.0, sd, 0);
+    normalize_prefix(normal, k);
+  } else {
+    for (int i = 0; i < k; ++i) normal[i] = 0.0;
+  }
+  if (R_finite(var) && var > 0.0) {
+    for (int i = 0; i < k; ++i) rbf[i] = std::exp(-dk[i] / (2.0 * var));
+    normalize_prefix(rbf, k);
+  } else {
+    for (int i = 0; i < k; ++i) rbf[i] = 0.0;
+  }
+
+  for (int i = 0; i < k; ++i) {
+    total[i] = rank.uniform[k][i] + student[i] + inverse[i] +
+      rank.exponential[k][i] + rank.lognormal[k][i] + rank.power[k][i] +
+      normal[i] + rbf[i];
+  }
+  normalize_prefix(total, k);
+
+  if (is_class) return weighted_mode_prefix(yk, total, k, cls, cls_totals);
+  double dot = 0.0;
+  for (int i = 0; i < k; ++i) dot += yk[i] * total[i];
   return dot;
 }
+
+struct PredictPathWorker : public Worker {
+  RMatrix<double> rpm_x;
+  RVector<double> yhat;
+  RMatrix<double> Xtest;
+  RVector<double> mins;
+  RVector<double> maxs;
+  RMatrix<double> out;
+  const int kmax, dist_code, n, p;
+  const bool is_class;
+  const RankComponents& rank;
+  std::vector<int> active;
+  std::vector<double> inv_range;
+
+  PredictPathWorker(const NumericMatrix& rpm_x_, const NumericVector& yhat_,
+                    const NumericMatrix& Xtest_, int kmax_, int dist_code_,
+                    const NumericVector& mins_, const NumericVector& maxs_,
+                    bool is_class_, const RankComponents& rank_, NumericMatrix& out_)
+      : rpm_x(rpm_x_), yhat(yhat_), Xtest(Xtest_), mins(mins_), maxs(maxs_),
+        out(out_), kmax(kmax_), dist_code(dist_code_), n(rpm_x_.nrow()),
+        p(rpm_x_.ncol()), is_class(is_class_), rank(rank_) {
+    for (int j = 0; j < p; ++j) {
+      const double range = maxs[j] - mins[j];
+      if (R_finite(range) && range > 0.0) { active.push_back(j); inv_range.push_back(1.0 / range); }
+    }
+  }
+
+  void distances_for_row(std::size_t r, std::vector<double>& d) const {
+    if (dist_code == 2) {
+      for (int i = 0; i < n; ++i) {
+        double mismatches = 0.0;
+        for (int j = 0; j < p; ++j) if (rpm_x(i, j) != Xtest(r, j)) mismatches += 1.0;
+        d[i] = mismatches / static_cast<double>(p);
+      }
+    } else if (active.empty()) {
+      std::fill(d.begin(), d.end(), 0.0);
+    } else if (dist_code == 1) {
+      for (int i = 0; i < n; ++i) {
+        double acc = 0.0;
+        for (std::size_t a = 0; a < active.size(); ++a) {
+          const int j = active[a]; acc += std::fabs((rpm_x(i, j) - Xtest(r, j)) * inv_range[a]);
+        }
+        d[i] = acc;
+      }
+    } else {
+      for (int i = 0; i < n; ++i) {
+        double acc = 0.0;
+        for (std::size_t a = 0; a < active.size(); ++a) {
+          const int j = active[a]; const double z = (rpm_x(i, j) - Xtest(r, j)) * inv_range[a]; acc += z * z;
+        }
+        d[i] = std::sqrt(acc);
+      }
+    }
+  }
+
+  double min_ties(const std::vector<double>& d, std::vector<double>& tied,
+                  std::vector<double>& weights) const {
+    double dmin = d[0];
+    for (int i = 1; i < n; ++i) if (d[i] < dmin) dmin = d[i];
+    tied.clear();
+    for (int i = 0; i < n; ++i) if (d[i] == dmin && R_finite(yhat[i])) tied.push_back(yhat[i]);
+    if (is_class) {
+      weights.assign(tied.size(), 1.0);
+      return weighted_mode(tied, weights);
+    }
+    return gravity_value(tied, false);
+  }
+
+  void operator()(std::size_t begin, std::size_t end) {
+    std::vector<double> d(n), dk(kmax), yk(kmax), tied, one_weights;
+    std::vector<int> idx(n);
+    std::vector<double> student(kmax), inverse(kmax), normal(kmax), rbf(kmax), total(kmax);
+    std::vector<double> cls(kmax), cls_totals(kmax);
+    for (std::size_t r = begin; r < end; ++r) {
+      distances_for_row(r, d);
+      for (int i = 0; i < n; ++i) idx[i] = i;
+      std::stable_sort(idx.begin(), idx.end(), [&d](int a, int b) { return d[a] < d[b]; });
+      for (int i = 0; i < kmax; ++i) { dk[i] = d[idx[i]]; yk[i] = yhat[idx[i]]; }
+      out(r, 0) = min_ties(d, tied, one_weights);
+      for (int k = 2; k <= kmax; ++k) {
+        out(r, k - 1) = predict_sorted_k_noalloc(dk, yk, k, is_class, rank,
+                                                 student, inverse, normal, rbf,
+                                                 total, cls, cls_totals);
+      }
+    }
+  }
+};
 
 // [[Rcpp::export]]
 NumericMatrix NNS_mreg_predict_path_v2_cpp(const NumericMatrix& rpm_x,
@@ -279,19 +436,12 @@ NumericMatrix NNS_mreg_predict_path_v2_cpp(const NumericMatrix& rpm_x,
   if (mins.size() != p || maxs.size() != p) stop("mins/maxs must have one value per column");
   if (kmax < 1) stop("kmax must be >= 1");
   if (kmax > n) kmax = n;
-  std::vector<int> active; std::vector<double> inv_range; active_columns(mins, maxs, active, inv_range);
-  std::vector< std::vector<double> > U(kmax+1), E(kmax+1), L(kmax+1), P(kmax+1);
-  for (int k=2; k<=kmax; ++k) rank_components(k, U[k], E[k], L[k], P[k]);
+  RankComponents rank(kmax);
   NumericMatrix out(m, kmax);
-  std::vector<double> d(n), dk(kmax), yk(kmax); std::vector<int> idx(n);
-  for (int r = 0; r < m; ++r) {
-    row_distances(rpm_x, Xtest, r, dist_code, active, inv_range, d);
-    for (int i = 0; i < n; ++i) idx[i] = i;
-    std::stable_sort(idx.begin(), idx.end(), [&d](int a, int b) { return d[a] < d[b]; });
-    for (int i = 0; i < kmax; ++i) { dk[i] = d[idx[i]]; yk[i] = yhat[idx[i]]; }
-    out(r,0) = aggregate_min_ties(d, yhat, is_class);
-    for (int k=2; k<=kmax; ++k) out(r,k-1) = predict_sorted_k(dk, yk, k, is_class, U[k], E[k], L[k], P[k]);
-  }
+  PredictPathWorker worker(rpm_x, yhat, Xtest, kmax, dist_code, mins, maxs,
+                           is_class, rank, out);
+  const int threads = std::max(1, nthreads);
+  if (threads == 1 || m < 2) worker(0, m); else parallelFor(0, m, worker, 1, threads);
   return out;
 }
 

--- a/src/NNS_mreg_setup.cpp
+++ b/src/NNS_mreg_setup.cpp
@@ -33,9 +33,13 @@ double reduce_numeric(std::vector<double>& v, int reducer, bool is_class) {
 int find_interval_one(double x, const NumericVector& b) {
   const int n = b.size();
   if (n == 0) return 0;
-  if (x <= b[0]) return 0;
-  if (x >= b[n - 1]) return n - 1;
-  return static_cast<int>(std::upper_bound(b.begin(), b.end(), x) - b.begin()) - 1;
+  // Match R's one-based findInterval(..., left.open = FALSE,
+  // rightmost.closed = TRUE) IDs.  The string IDs are sorted
+  // lexicographically by split(), so a zero-based one-off shift changes RPM
+  // row ordering once IDs reach two digits and can alter stable tie-breaks.
+  if (x <= b[0]) return 1;
+  if (x >= b[n - 1]) return n;
+  return static_cast<int>(std::upper_bound(b.begin(), b.end(), x) - b.begin());
 }
 
 std::string id_for_row(const NumericMatrix& X, const List& boundaries, int r) {

--- a/src/NNS_mreg_setup.cpp
+++ b/src/NNS_mreg_setup.cpp
@@ -1,0 +1,76 @@
+#include <Rcpp.h>
+#include <algorithm>
+#include <cstring>
+#include <sstream>
+#include <unordered_map>
+using namespace Rcpp;
+
+double gravity_value(std::vector<double> x, bool discrete);
+
+namespace {
+double reduce_numeric(std::vector<double> v, int reducer, bool is_class) {
+  v.erase(std::remove_if(v.begin(), v.end(), [](double x){ return !R_finite(x); }), v.end());
+  if (v.empty()) return NA_REAL;
+  std::sort(v.begin(), v.end());
+  if (is_class || reducer == 2) {
+    double best = v[0]; int bestn = 0;
+    for (std::size_t i=0; i<v.size();) { double val=v[i]; int n=0; while(i<v.size() && v[i]==val){++i;++n;} if(n>bestn){bestn=n; best=val;} }
+    return best;
+  }
+  if (reducer == 1) {
+    std::size_t n=v.size(); return (n%2) ? v[n/2] : (v[n/2-1]+v[n/2])/2.0;
+  }
+  if (reducer == 3) return gravity_value(v, false);
+  double s=0; for(double x:v) s+=x; return s/static_cast<double>(v.size());
+}
+int find_interval_one(double x, const NumericVector& b) {
+  int n=b.size(); if(n==0) return 0;
+  if (x <= b[0]) return 0;
+  if (x >= b[n-1]) return n-1;
+  return static_cast<int>(std::upper_bound(b.begin(), b.end(), x) - b.begin()) - 1;
+}
+std::string id_for_row(const NumericMatrix& X, const List& boundaries, int r) {
+  std::ostringstream os;
+  for (int j=0; j<X.ncol(); ++j) { if(j) os << "."; os << find_interval_one(X(r,j), boundaries[j]); }
+  return os.str();
+}
+}
+
+// [[Rcpp::export]]
+IntegerVector NNS_duplicate_column_map_cpp(const NumericMatrix& X) {
+  const int n=X.nrow(), p=X.ncol();
+  IntegerVector rep(p);
+  std::unordered_map<std::string, std::vector<int> > seen;
+  for(int j=0;j<p;++j){
+    std::string key; key.reserve(n*sizeof(double));
+    for(int i=0;i<n;++i){ double v=X(i,j); key.append(reinterpret_cast<const char*>(&v), sizeof(double)); }
+    int r=j;
+    auto it=seen.find(key);
+    if(it!=seen.end()){
+      for(int cand: it->second){ bool same=true; for(int i=0;i<n && same;++i) same = (X(i,j)==X(i,cand)); if(same){r=cand; break;} }
+      it->second.push_back(j);
+    } else seen[key]=std::vector<int>(1,j);
+    rep[j]=r+1;
+  }
+  return rep;
+}
+
+// [[Rcpp::export]]
+List NNS_mreg_setup_cpp(const NumericMatrix& X, const NumericVector& y,
+                        const List& boundaries, int reducer_code, bool is_class) {
+  const int nr=X.nrow(), p=X.ncol();
+  if(y.size()!=nr) stop("y length must equal nrow(X)");
+  CharacterVector ids(nr);
+  for(int i=0;i<nr;++i) ids[i]=id_for_row(X,boundaries,i);
+  std::vector<std::string> unique;
+  unique.reserve(nr);
+  for(int i=0;i<nr;++i) unique.push_back(as<std::string>(ids[i]));
+  std::sort(unique.begin(), unique.end()); unique.erase(std::unique(unique.begin(), unique.end()), unique.end());
+  NumericMatrix rpm(unique.size(), p+1);
+  for(std::size_t g=0; g<unique.size(); ++g){
+    for(int j=0;j<p;++j){ std::vector<double> vals; for(int i=0;i<nr;++i) if(as<std::string>(ids[i])==unique[g]) vals.push_back(X(i,j)); rpm(g,j)=reduce_numeric(vals,reducer_code,false); }
+    std::vector<double> yy; for(int i=0;i<nr;++i) if(as<std::string>(ids[i])==unique[g]) yy.push_back(y[i]); rpm(g,p)=reduce_numeric(yy,reducer_code,is_class);
+  }
+  CharacterVector row_ids(unique.size()); for(std::size_t i=0;i<unique.size();++i) row_ids[i]=unique[i];
+  return List::create(_["RPM"] = rpm, _["ids"] = ids, _["row_ids"] = row_ids);
+}

--- a/src/NNS_mreg_setup.cpp
+++ b/src/NNS_mreg_setup.cpp
@@ -8,49 +8,70 @@ using namespace Rcpp;
 double gravity_value(std::vector<double> x, bool discrete);
 
 namespace {
-double reduce_numeric(std::vector<double> v, int reducer, bool is_class) {
+double reduce_numeric(std::vector<double>& v, int reducer, bool is_class) {
   v.erase(std::remove_if(v.begin(), v.end(), [](double x){ return !R_finite(x); }), v.end());
   if (v.empty()) return NA_REAL;
   std::sort(v.begin(), v.end());
   if (is_class || reducer == 2) {
     double best = v[0]; int bestn = 0;
-    for (std::size_t i=0; i<v.size();) { double val=v[i]; int n=0; while(i<v.size() && v[i]==val){++i;++n;} if(n>bestn){bestn=n; best=val;} }
+    for (std::size_t i = 0; i < v.size();) {
+      const double val = v[i]; int n = 0;
+      while (i < v.size() && v[i] == val) { ++i; ++n; }
+      if (n > bestn) { bestn = n; best = val; }
+    }
     return best;
   }
   if (reducer == 1) {
-    std::size_t n=v.size(); return (n%2) ? v[n/2] : (v[n/2-1]+v[n/2])/2.0;
+    const std::size_t n = v.size();
+    return (n % 2) ? v[n / 2] : (v[n / 2 - 1] + v[n / 2]) / 2.0;
   }
   if (reducer == 3) return gravity_value(v, false);
-  double s=0; for(double x:v) s+=x; return s/static_cast<double>(v.size());
+  double s = 0.0; for (double x : v) s += x;
+  return s / static_cast<double>(v.size());
 }
+
 int find_interval_one(double x, const NumericVector& b) {
-  int n=b.size(); if(n==0) return 0;
+  const int n = b.size();
+  if (n == 0) return 0;
   if (x <= b[0]) return 0;
-  if (x >= b[n-1]) return n-1;
+  if (x >= b[n - 1]) return n - 1;
   return static_cast<int>(std::upper_bound(b.begin(), b.end(), x) - b.begin()) - 1;
 }
+
 std::string id_for_row(const NumericMatrix& X, const List& boundaries, int r) {
   std::ostringstream os;
-  for (int j=0; j<X.ncol(); ++j) { if(j) os << "."; os << find_interval_one(X(r,j), boundaries[j]); }
+  for (int j = 0; j < X.ncol(); ++j) {
+    if (j) os << ".";
+    os << find_interval_one(X(r, j), boundaries[j]);
+  }
   return os.str();
 }
 }
 
 // [[Rcpp::export]]
 IntegerVector NNS_duplicate_column_map_cpp(const NumericMatrix& X) {
-  const int n=X.nrow(), p=X.ncol();
+  const int n = X.nrow(), p = X.ncol();
   IntegerVector rep(p);
   std::unordered_map<std::string, std::vector<int> > seen;
-  for(int j=0;j<p;++j){
-    std::string key; key.reserve(n*sizeof(double));
-    for(int i=0;i<n;++i){ double v=X(i,j); key.append(reinterpret_cast<const char*>(&v), sizeof(double)); }
-    int r=j;
-    auto it=seen.find(key);
-    if(it!=seen.end()){
-      for(int cand: it->second){ bool same=true; for(int i=0;i<n && same;++i) same = (X(i,j)==X(i,cand)); if(same){r=cand; break;} }
+  for (int j = 0; j < p; ++j) {
+    std::string key; key.reserve(n * sizeof(double));
+    for (int i = 0; i < n; ++i) {
+      const double v = X(i, j);
+      key.append(reinterpret_cast<const char*>(&v), sizeof(double));
+    }
+    int r = j;
+    auto it = seen.find(key);
+    if (it != seen.end()) {
+      for (int cand : it->second) {
+        bool same = true;
+        for (int i = 0; i < n && same; ++i) same = (X(i, j) == X(i, cand));
+        if (same) { r = cand; break; }
+      }
       it->second.push_back(j);
-    } else seen[key]=std::vector<int>(1,j);
-    rep[j]=r+1;
+    } else {
+      seen[key] = std::vector<int>(1, j);
+    }
+    rep[j] = r + 1;
   }
   return rep;
 }
@@ -58,19 +79,35 @@ IntegerVector NNS_duplicate_column_map_cpp(const NumericMatrix& X) {
 // [[Rcpp::export]]
 List NNS_mreg_setup_cpp(const NumericMatrix& X, const NumericVector& y,
                         const List& boundaries, int reducer_code, bool is_class) {
-  const int nr=X.nrow(), p=X.ncol();
-  if(y.size()!=nr) stop("y length must equal nrow(X)");
+  const int nr = X.nrow(), p = X.ncol();
+  if (y.size() != nr) stop("y length must equal nrow(X)");
   CharacterVector ids(nr);
-  for(int i=0;i<nr;++i) ids[i]=id_for_row(X,boundaries,i);
-  std::vector<std::string> unique;
-  unique.reserve(nr);
-  for(int i=0;i<nr;++i) unique.push_back(as<std::string>(ids[i]));
-  std::sort(unique.begin(), unique.end()); unique.erase(std::unique(unique.begin(), unique.end()), unique.end());
-  NumericMatrix rpm(unique.size(), p+1);
-  for(std::size_t g=0; g<unique.size(); ++g){
-    for(int j=0;j<p;++j){ std::vector<double> vals; for(int i=0;i<nr;++i) if(as<std::string>(ids[i])==unique[g]) vals.push_back(X(i,j)); rpm(g,j)=reduce_numeric(vals,reducer_code,false); }
-    std::vector<double> yy; for(int i=0;i<nr;++i) if(as<std::string>(ids[i])==unique[g]) yy.push_back(y[i]); rpm(g,p)=reduce_numeric(yy,reducer_code,is_class);
+  std::unordered_map<std::string, std::vector<int> > groups;
+  groups.reserve(static_cast<std::size_t>(nr) * 2);
+  for (int i = 0; i < nr; ++i) {
+    const std::string id = id_for_row(X, boundaries, i);
+    ids[i] = id;
+    groups[id].push_back(i);
   }
-  CharacterVector row_ids(unique.size()); for(std::size_t i=0;i<unique.size();++i) row_ids[i]=unique[i];
+  std::vector<std::string> ordered_ids;
+  ordered_ids.reserve(groups.size());
+  for (const auto& kv : groups) ordered_ids.push_back(kv.first);
+  std::sort(ordered_ids.begin(), ordered_ids.end());
+
+  NumericMatrix rpm(ordered_ids.size(), p + 1);
+  std::vector<double> vals;
+  for (std::size_t g = 0; g < ordered_ids.size(); ++g) {
+    const std::vector<int>& idx = groups[ordered_ids[g]];
+    for (int j = 0; j < p; ++j) {
+      vals.clear(); vals.reserve(idx.size());
+      for (int row : idx) vals.push_back(X(row, j));
+      rpm(g, j) = reduce_numeric(vals, reducer_code, false);
+    }
+    vals.clear(); vals.reserve(idx.size());
+    for (int row : idx) vals.push_back(y[row]);
+    rpm(g, p) = reduce_numeric(vals, reducer_code, is_class);
+  }
+  CharacterVector row_ids(ordered_ids.size());
+  for (std::size_t i = 0; i < ordered_ids.size(); ++i) row_ids[i] = ordered_ids[i];
   return List::create(_["RPM"] = rpm, _["ids"] = ids, _["row_ids"] = row_ids);
 }

--- a/src/NNS_mreg_setup.cpp
+++ b/src/NNS_mreg_setup.cpp
@@ -34,11 +34,12 @@ int find_interval_one(double x, const NumericVector& b) {
   const int n = b.size();
   if (n == 0) return 0;
   // Match R's one-based findInterval(..., left.open = FALSE,
-  // rightmost.closed = TRUE) IDs.  The string IDs are sorted
-  // lexicographically by split(), so a zero-based one-off shift changes RPM
-  // row ordering once IDs reach two digits and can alter stable tie-breaks.
-  if (x <= b[0]) return 1;
-  if (x >= b[n - 1]) return n;
+  // rightmost.closed = TRUE) IDs exactly:
+  // below first -> 0; exact final boundary -> n - 1; above final -> n.
+  // The string IDs are sorted lexicographically by split(), so parity here is
+  // required to preserve RPM row ordering and stable tie-break behavior.
+  if (x < b[0]) return 0;
+  if (x == b[n - 1]) return std::max(0, n - 1);
   return static_cast<int>(std::upper_bound(b.begin(), b.end(), x) - b.begin());
 }
 

--- a/src/NNS_stack_fast.cpp
+++ b/src/NNS_stack_fast.cpp
@@ -1,0 +1,29 @@
+#include <Rcpp.h>
+#include <unordered_map>
+#include <cstring>
+using namespace Rcpp;
+
+// [[Rcpp::export]]
+List NNS_xstar_path_cpp(const NumericMatrix& train_design,
+                        const NumericMatrix& test_design,
+                        const NumericVector& coefficients,
+                        const IntegerVector& column_order,
+                        int nthreads) {
+  int ntr=train_design.nrow(), nte=test_design.nrow(), p=train_design.ncol();
+  if(test_design.ncol()!=p || coefficients.size()!=p) stop("incompatible dimensions");
+  NumericMatrix train(ntr,p), test(nte,p); NumericVector denom(p); IntegerVector rep(p);
+  std::vector<double> num_tr(ntr,0.0), num_te(nte,0.0); double den=0.0; bool any_nonzero=false;
+  for(int c=0;c<p;++c) if(coefficients[c]!=0.0) any_nonzero=true;
+  for(int m=0;m<p;++m){
+    int j=column_order[m]-1; double coef=coefficients[j];
+    if(!any_nonzero) { coef=1.0; den += 1.0; }
+    else if(coef!=0.0) den += 1.0;
+    for(int i=0;i<ntr;++i) num_tr[i] += train_design(i,j)*coef;
+    for(int i=0;i<nte;++i) num_te[i] += test_design(i,j)*coef;
+    denom[m]=den;
+    for(int i=0;i<ntr;++i) train(i,m)=num_tr[i]/den;
+    for(int i=0;i<nte;++i) test(i,m)=num_te[i]/den;
+  }
+  for(int m=0;m<p;++m){ rep[m]=m+1; for(int r=0;r<m;++r){ bool same=true; for(int i=0;i<ntr && same;++i) same=(train(i,m)==train(i,r)); for(int i=0;i<nte && same;++i) same=(test(i,m)==test(i,r)); if(same){rep[m]=r+1; break;} } }
+  return List::create(_["train"]=train, _["test"]=test, _["denominator"]=denom, _["column_order"]=column_order, _["representative"]=rep);
+}

--- a/src/NNS_stack_fast.cpp
+++ b/src/NNS_stack_fast.cpp
@@ -1,7 +1,37 @@
 #include <Rcpp.h>
-#include <unordered_map>
-#include <cstring>
+#include <RcppParallel.h>
+#include <vector>
 using namespace Rcpp;
+using namespace RcppParallel;
+
+struct FillProjectionWorker : public Worker {
+  RMatrix<double> design;
+  RMatrix<double> out;
+  const std::vector<int>& order;
+  const std::vector<double>& coef;
+  const std::vector<double>& denom;
+  const bool all_zero;
+
+  FillProjectionWorker(const NumericMatrix& design_, NumericMatrix& out_,
+                       const std::vector<int>& order_,
+                       const std::vector<double>& coef_,
+                       const std::vector<double>& denom_, bool all_zero_)
+      : design(design_), out(out_), order(order_), coef(coef_),
+        denom(denom_), all_zero(all_zero_) {}
+
+  void operator()(std::size_t begin, std::size_t end) {
+    const int p = out.ncol();
+    for (std::size_t i = begin; i < end; ++i) {
+      double numerator = 0.0;
+      for (int m = 0; m < p; ++m) {
+        const int j = order[m];
+        const double c = all_zero ? 1.0 : coef[j];
+        numerator += design(i, j) * c;
+        out(i, m) = numerator / denom[m];
+      }
+    }
+  }
+};
 
 // [[Rcpp::export]]
 List NNS_xstar_path_cpp(const NumericMatrix& train_design,
@@ -9,21 +39,45 @@ List NNS_xstar_path_cpp(const NumericMatrix& train_design,
                         const NumericVector& coefficients,
                         const IntegerVector& column_order,
                         int nthreads) {
-  int ntr=train_design.nrow(), nte=test_design.nrow(), p=train_design.ncol();
-  if(test_design.ncol()!=p || coefficients.size()!=p) stop("incompatible dimensions");
-  NumericMatrix train(ntr,p), test(nte,p); NumericVector denom(p); IntegerVector rep(p);
-  std::vector<double> num_tr(ntr,0.0), num_te(nte,0.0); double den=0.0; bool any_nonzero=false;
-  for(int c=0;c<p;++c) if(coefficients[c]!=0.0) any_nonzero=true;
-  for(int m=0;m<p;++m){
-    int j=column_order[m]-1; double coef=coefficients[j];
-    if(!any_nonzero) { coef=1.0; den += 1.0; }
-    else if(coef!=0.0) den += 1.0;
-    for(int i=0;i<ntr;++i) num_tr[i] += train_design(i,j)*coef;
-    for(int i=0;i<nte;++i) num_te[i] += test_design(i,j)*coef;
-    denom[m]=den;
-    for(int i=0;i<ntr;++i) train(i,m)=num_tr[i]/den;
-    for(int i=0;i<nte;++i) test(i,m)=num_te[i]/den;
+  const int ntr = train_design.nrow(), nte = test_design.nrow(), p = train_design.ncol();
+  if (test_design.ncol() != p || coefficients.size() != p || column_order.size() != p) {
+    stop("incompatible dimensions");
   }
-  for(int m=0;m<p;++m){ rep[m]=m+1; for(int r=0;r<m;++r){ bool same=true; for(int i=0;i<ntr && same;++i) same=(train(i,m)==train(i,r)); for(int i=0;i<nte && same;++i) same=(test(i,m)==test(i,r)); if(same){rep[m]=r+1; break;} } }
-  return List::create(_["train"]=train, _["test"]=test, _["denominator"]=denom, _["column_order"]=column_order, _["representative"]=rep);
+  NumericMatrix train(ntr, p), test(nte, p);
+  NumericVector denominator(p);
+  IntegerVector representative(p);
+  std::vector<int> order(p);
+  std::vector<double> coef(p), denom(p);
+  bool all_zero = true;
+  for (int j = 0; j < p; ++j) {
+    order[j] = column_order[j] - 1;
+    coef[j] = coefficients[j];
+    if (coef[j] != 0.0) all_zero = false;
+  }
+  double den = 0.0;
+  for (int m = 0; m < p; ++m) {
+    const int j = order[m];
+    if (all_zero || coef[j] != 0.0) den += 1.0;
+    denom[m] = den;
+    denominator[m] = den;
+  }
+  const int threads = std::max(1, nthreads);
+  FillProjectionWorker train_worker(train_design, train, order, coef, denom, all_zero);
+  FillProjectionWorker test_worker(test_design, test, order, coef, denom, all_zero);
+  if (threads == 1 || ntr < 2) train_worker(0, ntr); else parallelFor(0, ntr, train_worker, 1, threads);
+  if (threads == 1 || nte < 2) test_worker(0, nte); else parallelFor(0, nte, test_worker, 1, threads);
+
+  for (int m = 0; m < p; ++m) {
+    representative[m] = m + 1;
+    for (int r = 0; r < m; ++r) {
+      bool same = true;
+      for (int i = 0; i < ntr && same; ++i) same = (train(i, m) == train(i, r));
+      for (int i = 0; i < nte && same; ++i) same = (test(i, m) == test(i, r));
+      if (same) { representative[m] = r + 1; break; }
+    }
+  }
+  return List::create(_["train"] = train, _["test"] = test,
+                      _["denominator"] = denominator,
+                      _["column_order"] = column_order,
+                      _["representative"] = representative);
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -114,6 +114,45 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// NNS_mreg_predict_path_v2_cpp
+NumericMatrix NNS_mreg_predict_path_v2_cpp(const NumericMatrix& rpm_x, const NumericVector& yhat, const NumericMatrix& Xtest, int kmax, int dist_code, const NumericVector& mins, const NumericVector& maxs, bool is_class, int nthreads);
+RcppExport SEXP _NNS_NNS_mreg_predict_path_v2_cpp(SEXP rpm_xSEXP, SEXP yhatSEXP, SEXP XtestSEXP, SEXP kmaxSEXP, SEXP dist_codeSEXP, SEXP minsSEXP, SEXP maxsSEXP, SEXP is_classSEXP, SEXP nthreadsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type rpm_x(rpm_xSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type yhat(yhatSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type Xtest(XtestSEXP);
+    Rcpp::traits::input_parameter< int >::type kmax(kmaxSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_code(dist_codeSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type mins(minsSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type maxs(maxsSEXP);
+    Rcpp::traits::input_parameter< bool >::type is_class(is_classSEXP);
+    Rcpp::traits::input_parameter< int >::type nthreads(nthreadsSEXP);
+    rcpp_result_gen = Rcpp::wrap(NNS_mreg_predict_path_v2_cpp(rpm_x, yhat, Xtest, kmax, dist_code, mins, maxs, is_class, nthreads));
+    return rcpp_result_gen;
+END_RCPP
+}
+
+// NNS_mreg_predict_v2_cpp
+NumericVector NNS_mreg_predict_v2_cpp(const NumericMatrix& rpm_x, const NumericVector& yhat, const NumericMatrix& Xtest, int k, int dist_code, const NumericVector& mins, const NumericVector& maxs, bool is_class, int nthreads);
+RcppExport SEXP _NNS_NNS_mreg_predict_v2_cpp(SEXP rpm_xSEXP, SEXP yhatSEXP, SEXP XtestSEXP, SEXP kSEXP, SEXP dist_codeSEXP, SEXP minsSEXP, SEXP maxsSEXP, SEXP is_classSEXP, SEXP nthreadsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen; Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type rpm_x(rpm_xSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type yhat(yhatSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type Xtest(XtestSEXP);
+    Rcpp::traits::input_parameter< int >::type k(kSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_code(dist_codeSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type mins(minsSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type maxs(maxsSEXP);
+    Rcpp::traits::input_parameter< bool >::type is_class(is_classSEXP);
+    Rcpp::traits::input_parameter< int >::type nthreads(nthreadsSEXP);
+    rcpp_result_gen = Rcpp::wrap(NNS_mreg_predict_v2_cpp(rpm_x, yhat, Xtest, k, dist_code, mins, maxs, is_class, nthreads));
+    return rcpp_result_gen;
+END_RCPP
+}
+
 // NNS_mreg_predict_path_cpp
 NumericMatrix NNS_mreg_predict_path_cpp(const NumericMatrix& rpm_x, const NumericVector& yhat, const NumericMatrix& Xtest, int kmax, int dist_code, const NumericVector& mins, const NumericVector& maxs, bool is_class);
 RcppExport SEXP _NNS_NNS_mreg_predict_path_cpp(SEXP rpm_xSEXP, SEXP yhatSEXP, SEXP XtestSEXP, SEXP kmaxSEXP, SEXP dist_codeSEXP, SEXP minsSEXP, SEXP maxsSEXP, SEXP is_classSEXP) {
@@ -740,6 +779,47 @@ BEGIN_RCPP
 END_RCPP
 }
 
+// NNS_duplicate_column_map_cpp
+IntegerVector NNS_duplicate_column_map_cpp(const NumericMatrix& X);
+RcppExport SEXP _NNS_NNS_duplicate_column_map_cpp(SEXP XSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen; Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type X(XSEXP);
+    rcpp_result_gen = Rcpp::wrap(NNS_duplicate_column_map_cpp(X));
+    return rcpp_result_gen;
+END_RCPP
+}
+
+// NNS_mreg_setup_cpp
+List NNS_mreg_setup_cpp(const NumericMatrix& X, const NumericVector& y, const List& boundaries, int reducer_code, bool is_class);
+RcppExport SEXP _NNS_NNS_mreg_setup_cpp(SEXP XSEXP, SEXP ySEXP, SEXP boundariesSEXP, SEXP reducer_codeSEXP, SEXP is_classSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen; Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type X(XSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type y(ySEXP);
+    Rcpp::traits::input_parameter< const List& >::type boundaries(boundariesSEXP);
+    Rcpp::traits::input_parameter< int >::type reducer_code(reducer_codeSEXP);
+    Rcpp::traits::input_parameter< bool >::type is_class(is_classSEXP);
+    rcpp_result_gen = Rcpp::wrap(NNS_mreg_setup_cpp(X, y, boundaries, reducer_code, is_class));
+    return rcpp_result_gen;
+END_RCPP
+}
+
+// NNS_xstar_path_cpp
+List NNS_xstar_path_cpp(const NumericMatrix& train_design, const NumericMatrix& test_design, const NumericVector& coefficients, const IntegerVector& column_order, int nthreads);
+RcppExport SEXP _NNS_NNS_xstar_path_cpp(SEXP train_designSEXP, SEXP test_designSEXP, SEXP coefficientsSEXP, SEXP column_orderSEXP, SEXP nthreadsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen; Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type train_design(train_designSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type test_design(test_designSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type coefficients(coefficientsSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type column_order(column_orderSEXP);
+    Rcpp::traits::input_parameter< int >::type nthreads(nthreadsSEXP);
+    rcpp_result_gen = Rcpp::wrap(NNS_xstar_path_cpp(train_design, test_design, coefficients, column_order, nthreads));
+    return rcpp_result_gen;
+END_RCPP
+}
+
 static const R_CallMethodDef CallEntries[] = {
     {"_NNS_NNS_dep_pair_cpp", (DL_FUNC) &_NNS_NNS_dep_pair_cpp, 5},
     {"_NNS_NNS_dep_matrix_cpp", (DL_FUNC) &_NNS_NNS_dep_matrix_cpp, 2},
@@ -748,6 +828,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_NNS_NNS_distance_bulk_cpp", (DL_FUNC) &_NNS_NNS_distance_bulk_cpp, 5},
     {"_NNS_NNS_distance_path_parallel_cpp", (DL_FUNC) &_NNS_NNS_distance_path_parallel_cpp, 6},
     {"_NNS_NNS_distance_path_single_parallel_cpp", (DL_FUNC) &_NNS_NNS_distance_path_single_parallel_cpp, 6},
+    {"_NNS_NNS_mreg_predict_path_v2_cpp", (DL_FUNC) &_NNS_NNS_mreg_predict_path_v2_cpp, 9},
+    {"_NNS_NNS_mreg_predict_v2_cpp", (DL_FUNC) &_NNS_NNS_mreg_predict_v2_cpp, 9},
     {"_NNS_NNS_mreg_predict_path_cpp", (DL_FUNC) &_NNS_NNS_mreg_predict_path_cpp, 8},
     {"_NNS_NNS_mreg_predict_cpp", (DL_FUNC) &_NNS_NNS_mreg_predict_cpp, 8},
     {"_NNS_NNS_part_cpp", (DL_FUNC) &_NNS_NNS_part_cpp, 8},
@@ -793,6 +875,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_NNS_PMMatrix_RCPP", (DL_FUNC) &_NNS_PMMatrix_RCPP, 6},
     {"_NNS_NNS_bin", (DL_FUNC) &_NNS_NNS_bin, 4},
     {"_NNS_stoch_superiority_cpp", (DL_FUNC) &_NNS_stoch_superiority_cpp, 2},
+    {"_NNS_NNS_duplicate_column_map_cpp", (DL_FUNC) &_NNS_NNS_duplicate_column_map_cpp, 1},
+    {"_NNS_NNS_mreg_setup_cpp", (DL_FUNC) &_NNS_NNS_mreg_setup_cpp, 5},
+    {"_NNS_NNS_xstar_path_cpp", (DL_FUNC) &_NNS_NNS_xstar_path_cpp, 5},
     {"_NNS_NNS_mreg_reduce_cpp", (DL_FUNC) &_NNS_NNS_mreg_reduce_cpp, 5},
     {NULL, NULL, 0}
 };

--- a/tests/testthat/helper-stack-parity.R
+++ b/tests/testthat/helper-stack-parity.R
@@ -1,0 +1,9 @@
+stack_with_native <- function(native, expr) {
+  old <- options(NNS.native.stack = native, NNS.native.mreg = native,
+                 NNS.native.univariate = native)
+  on.exit(options(old), add = TRUE)
+  force(expr)
+}
+expect_numeric_close <- function(x, y, tol = 1e-12) {
+  expect_equal(as.numeric(x), as.numeric(y), tolerance = tol, scale = 1)
+}

--- a/tests/testthat/helper-stack-parity.R
+++ b/tests/testthat/helper-stack-parity.R
@@ -4,6 +4,14 @@ stack_with_native <- function(native, expr) {
   on.exit(options(old), add = TRUE)
   force(expr)
 }
-expect_numeric_close <- function(x, y, tol = 1e-12) {
-  expect_equal(as.numeric(x), as.numeric(y), tolerance = tol, scale = 1)
+expect_numeric_close <- function(actual, expected, tolerance = 1e-12) {
+  testthat::expect_identical(dim(actual), dim(expected))
+  testthat::expect_identical(names(actual), names(expected))
+  a <- as.numeric(actual)
+  b <- as.numeric(expected)
+  testthat::expect_identical(is.na(a), is.na(b))
+  keep <- is.finite(a) & is.finite(b)
+  if (any(keep)) {
+    testthat::expect_lte(max(abs(a[keep] - b[keep])), tolerance)
+  }
 }

--- a/tests/testthat/test-mreg-path-native.R
+++ b/tests/testthat/test-mreg-path-native.R
@@ -4,3 +4,16 @@ test_that("v2 all-k path matches legacy path on smoke data", {
   nat <- NNS_mreg_predict_path_v2_cpp(rpm[,1,drop=FALSE], rpm[,2], x, 3L, 0L, mins, maxs, FALSE, 1L)
   expect_equal(nat, old, tolerance = 1e-12)
 })
+
+test_that("v2 all-k path is deterministic with multiple native threads", {
+  rpm_x <- matrix(seq(0, 1, length.out = 40), ncol = 2)
+  y <- seq_len(nrow(rpm_x)) / 10
+  xt <- rpm_x[c(1, 5, 10), , drop = FALSE]
+  one <- NNS_mreg_predict_path_v2_cpp(rpm_x, y, xt, 6L, 0L,
+                                      apply(rpm_x, 2, min), apply(rpm_x, 2, max),
+                                      FALSE, 1L)
+  many <- NNS_mreg_predict_path_v2_cpp(rpm_x, y, xt, 6L, 0L,
+                                       apply(rpm_x, 2, min), apply(rpm_x, 2, max),
+                                       FALSE, 2L)
+  expect_equal(many, one, tolerance = 1e-12)
+})

--- a/tests/testthat/test-mreg-path-native.R
+++ b/tests/testthat/test-mreg-path-native.R
@@ -1,0 +1,6 @@
+test_that("v2 all-k path matches legacy path on smoke data", {
+  rpm <- cbind(c(0,1,2), c(0,1,4)); x <- cbind(c(.5,1.5)); mins <- 0; maxs <- 2
+  old <- NNS_mreg_predict_path_cpp(rpm[,1,drop=FALSE], rpm[,2], x, 3L, 0L, mins, maxs, FALSE)
+  nat <- NNS_mreg_predict_path_v2_cpp(rpm[,1,drop=FALSE], rpm[,2], x, 3L, 0L, mins, maxs, FALSE, 1L)
+  expect_equal(nat, old, tolerance = 1e-12)
+})

--- a/tests/testthat/test-mreg-setup-native.R
+++ b/tests/testthat/test-mreg-setup-native.R
@@ -4,20 +4,63 @@ test_that("native mreg setup returns RPM and duplicate map smoke outputs", {
   expect_true(is.data.frame(prep$RPM)); expect_identical(as.integer(NNS_duplicate_column_map_cpp(X)), c(1L,1L))
 })
 
-test_that("native mreg setup preserves one-based findInterval IDs and RPM order", {
-  X <- matrix(seq_len(12), ncol = 1, dimnames = list(NULL, "x"))
-  y <- seq_len(12)
-  boundaries <- list(seq_len(12))
+test_that("native mreg setup preserves one-based rightmost-closed findInterval IDs", {
+  X <- matrix(as.numeric(1:12), ncol = 1, dimnames = list(NULL, "x"))
+  y <- as.numeric(1:12)
+  boundaries <- list(as.numeric(1:12))
   native <- NNS_mreg_setup_cpp(X, y, boundaries, 3L, FALSE)
   reference_ids <- as.character(findInterval(X[, 1], boundaries[[1]],
                                              left.open = FALSE,
                                              rightmost.closed = TRUE))
   expect_identical(as.character(native$ids), reference_ids)
+  expect_identical(tail(as.character(native$ids), 2), c("11", "11"))
 
   native_rpm <- as.data.frame(native$RPM)
   names(native_rpm) <- c("x", "y.hat")
   reference_rpm <- .nns_mreg_build_rpm(as.data.frame(X), y, reference_ids,
                                        "off", FALSE)
   expect_identical(native_rpm$x, reference_rpm$x)
+  expect_identical(native_rpm$y.hat, reference_rpm$y.hat)
+  expect_equal(tail(native_rpm$x, 1), 11.5)
+  expect_equal(tail(native_rpm$y.hat, 1), 11.5)
+})
+
+test_that("native interval IDs match R for below first, exact boundaries, and above final", {
+  boundaries <- list(as.numeric(c(1, 2, 3, 4)))
+  X <- matrix(as.numeric(c(0, 1, 1.5, 2, 3.5, 4, 5)), ncol = 1)
+  native <- NNS_mreg_setup_cpp(X, seq_len(nrow(X)), boundaries, 3L, FALSE)
+  reference_ids <- as.character(findInterval(X[, 1], boundaries[[1]],
+                                             left.open = FALSE,
+                                             rightmost.closed = TRUE))
+  expect_identical(as.character(native$ids), reference_ids)
+  expect_identical(as.character(native$ids), as.character(c(0, 1, 1, 2, 3, 3, 4)))
+})
+
+test_that("native interval IDs match R across multiple predictors and boundary counts", {
+  X <- cbind(
+    a = as.numeric(c(0, 1, 1.5, 2, 3.5, 4, 5, 4, 4)),
+    b = as.numeric(c(-1, 0, 5, 10, 20, 20, 25, 20, 20)),
+    c = rep(7, 9)
+  )
+  boundaries <- list(
+    as.numeric(c(1, 2, 3, 4)),
+    as.numeric(c(0, 10, 20)),
+    as.numeric(7)
+  )
+  native <- NNS_mreg_setup_cpp(X, seq_len(nrow(X)), boundaries, 3L, FALSE)
+  id_parts <- lapply(seq_along(boundaries), function(j) {
+    findInterval(X[, j], boundaries[[j]], left.open = FALSE,
+                 rightmost.closed = TRUE)
+  })
+  reference_ids <- do.call(paste, c(as.data.frame(id_parts), sep = "."))
+  expect_identical(as.character(native$ids), reference_ids)
+
+  native_rpm <- as.data.frame(native$RPM)
+  names(native_rpm) <- c(colnames(X), "y.hat")
+  reference_rpm <- .nns_mreg_build_rpm(as.data.frame(X), seq_len(nrow(X)),
+                                       reference_ids, "off", FALSE)
+  expect_identical(native_rpm$a, reference_rpm$a)
+  expect_identical(native_rpm$b, reference_rpm$b)
+  expect_identical(native_rpm$c, reference_rpm$c)
   expect_identical(native_rpm$y.hat, reference_rpm$y.hat)
 })

--- a/tests/testthat/test-mreg-setup-native.R
+++ b/tests/testthat/test-mreg-setup-native.R
@@ -3,3 +3,21 @@ test_that("native mreg setup returns RPM and duplicate map smoke outputs", {
   prep <- .nns_mreg_prepare_model(X, y, order = "max", use.native = TRUE)
   expect_true(is.data.frame(prep$RPM)); expect_identical(as.integer(NNS_duplicate_column_map_cpp(X)), c(1L,1L))
 })
+
+test_that("native mreg setup preserves one-based findInterval IDs and RPM order", {
+  X <- matrix(seq_len(12), ncol = 1, dimnames = list(NULL, "x"))
+  y <- seq_len(12)
+  boundaries <- list(seq_len(12))
+  native <- NNS_mreg_setup_cpp(X, y, boundaries, 3L, FALSE)
+  reference_ids <- as.character(findInterval(X[, 1], boundaries[[1]],
+                                             left.open = FALSE,
+                                             rightmost.closed = TRUE))
+  expect_identical(as.character(native$ids), reference_ids)
+
+  native_rpm <- as.data.frame(native$RPM)
+  names(native_rpm) <- c("x", "y.hat")
+  reference_rpm <- .nns_mreg_build_rpm(as.data.frame(X), y, reference_ids,
+                                       "off", FALSE)
+  expect_identical(native_rpm$x, reference_rpm$x)
+  expect_identical(native_rpm$y.hat, reference_rpm$y.hat)
+})

--- a/tests/testthat/test-mreg-setup-native.R
+++ b/tests/testthat/test-mreg-setup-native.R
@@ -21,8 +21,18 @@ test_that("native mreg setup preserves one-based rightmost-closed findInterval I
                                        "off", FALSE)
   expect_identical(native_rpm$x, reference_rpm$x)
   expect_identical(native_rpm$y.hat, reference_rpm$y.hat)
-  expect_equal(tail(native_rpm$x, 1), 11.5)
-  expect_equal(tail(native_rpm$y.hat, 1), 11.5)
+
+  reference_groups <- split(seq_len(nrow(X)), reference_ids)
+  expect_identical(
+    names(reference_groups),
+    c("1", "10", "11", "2", "3", "4", "5", "6", "7", "8", "9")
+  )
+  merged_group_position <- match("11", names(reference_groups))
+  expect_false(is.na(merged_group_position))
+  expect_equal(native_rpm$x[merged_group_position], 11.5)
+  expect_equal(native_rpm$y.hat[merged_group_position], 11.5)
+  expect_equal(tail(native_rpm$x, 1), 9)
+  expect_equal(tail(native_rpm$y.hat, 1), 9)
 })
 
 test_that("native interval IDs match R for below first, exact boundaries, and above final", {

--- a/tests/testthat/test-mreg-setup-native.R
+++ b/tests/testthat/test-mreg-setup-native.R
@@ -1,0 +1,5 @@
+test_that("native mreg setup returns RPM and duplicate map smoke outputs", {
+  X <- cbind(a = c(1,1,2,2), b = c(1,1,2,2)); y <- c(1,2,3,4)
+  prep <- .nns_mreg_prepare_model(X, y, order = "max", use.native = TRUE)
+  expect_true(is.data.frame(prep$RPM)); expect_identical(as.integer(NNS_duplicate_column_map_cpp(X)), c(1L,1L))
+})

--- a/tests/testthat/test-stack-method1-native-parity.R
+++ b/tests/testthat/test-stack-method1-native-parity.R
@@ -1,0 +1,7 @@
+test_that("method 1 native and reference select identical n.best on regression smoke case", {
+  set.seed(11); x <- data.frame(a = rnorm(24), b = rnorm(24)); y <- x$a - x$b^2
+  ref <- stack_with_native(FALSE, NNS.stack(x, y, IVs.test = x[1:3,], method = 1, folds = 2, ncores = 1, status = FALSE))
+  nat <- stack_with_native(TRUE, NNS.stack(x, y, IVs.test = x[1:3,], method = 1, folds = 2, ncores = 1, status = FALSE))
+  expect_identical(nat$NNS.reg.n.best, ref$NNS.reg.n.best)
+  expect_numeric_close(nat$reg, ref$reg)
+})

--- a/tests/testthat/test-stack-method2-native-parity.R
+++ b/tests/testthat/test-stack-method2-native-parity.R
@@ -1,0 +1,7 @@
+test_that("method 2 native and reference select identical dimension count on smoke case", {
+  set.seed(12); x <- data.frame(a = rnorm(24), b = rnorm(24), c = rnorm(24)); y <- x$a + x$b
+  ref <- stack_with_native(FALSE, NNS.stack(x, y, IVs.test = x[1:3,], method = 2, folds = 2, ncores = 1, status = FALSE))
+  nat <- stack_with_native(TRUE, NNS.stack(x, y, IVs.test = x[1:3,], method = 2, folds = 2, ncores = 1, status = FALSE))
+  expect_identical(nat$NNS.dim.red.threshold, ref$NNS.dim.red.threshold)
+  expect_numeric_close(nat$dim.red, ref$dim.red)
+})

--- a/tests/testthat/test-stack-native-parity.R
+++ b/tests/testthat/test-stack-native-parity.R
@@ -1,0 +1,5 @@
+test_that("native backend options are accepted", {
+  old <- options(NNS.native.stack = TRUE, NNS.native.mreg = TRUE, NNS.native.univariate = TRUE)
+  on.exit(options(old), add = TRUE)
+  expect_true(isTRUE(getOption("NNS.native.stack")))
+})

--- a/tests/testthat/test-univariate-fast-parity.R
+++ b/tests/testthat/test-univariate-fast-parity.R
@@ -1,0 +1,6 @@
+test_that("univariate fast helper matches point estimates from public path", {
+  set.seed(13); x <- rnorm(20); y <- sin(x); test <- x[1:5]
+  fast <- .nns_reg_univariate_fast(x, y, test)
+  pub <- NNS.reg(x, y, point.est = test, plot = FALSE, residual.plot = FALSE, point.only = TRUE)
+  expect_equal(fast$prediction, as.numeric(pub$Point.est), tolerance = 1e-12)
+})

--- a/tests/testthat/test-xstar-path-native.R
+++ b/tests/testthat/test-xstar-path-native.R
@@ -6,3 +6,13 @@ test_that("native xstar path matches active coefficient projections including ze
   z <- NNS_xstar_path_cpp(train, test, c(0,0,0), seq_len(3), 1L)
   expect_equal(z$train[,2], rowMeans(train[,1:2]))
 })
+
+test_that("native xstar path is deterministic with multiple threads", {
+  train <- matrix(seq_len(60), 20, 3); test <- matrix(seq_len(15), 5, 3)
+  coef <- c(3, 0, -2); ord <- order(abs(coef), decreasing = TRUE, na.last = NA, method = "radix")
+  one <- NNS_xstar_path_cpp(train, test, coef, ord, 1L)
+  many <- NNS_xstar_path_cpp(train, test, coef, ord, 2L)
+  expect_equal(many$train, one$train, tolerance = 1e-14)
+  expect_equal(many$test, one$test, tolerance = 1e-14)
+  expect_identical(many$representative, one$representative)
+})

--- a/tests/testthat/test-xstar-path-native.R
+++ b/tests/testthat/test-xstar-path-native.R
@@ -1,0 +1,8 @@
+test_that("native xstar path matches active coefficient projections including zero fallback", {
+  train <- matrix(1:12, 4); test <- matrix(13:18, 2); coef <- c(2, 0, -1)
+  ord <- order(abs(coef), decreasing = TRUE, na.last = NA, method = "radix")
+  out <- NNS_xstar_path_cpp(train, test, coef, ord, 1L)
+  expect_equal(dim(out$train), c(4L, 3L)); expect_equal(out$column_order, ord)
+  z <- NNS_xstar_path_cpp(train, test, c(0,0,0), seq_len(3), 1L)
+  expect_equal(z$train[,2], rowMeans(train[,1:2]))
+})


### PR DESCRIPTION
### Motivation

- Restore Method 1 NNS.stack performance while preserving the corrected behavior and avoid calling the full public `NNS.reg()` inside folds purely to obtain an RPM. 
- Move heavy per-fold RPM/interval work into native code, cache duplicate predictor partitions, and provide native all-k/single-k prediction kernels to eliminate the pre-fold explosion.
- Provide native cumulative X-star projections for Method 2 and reuse duplicate candidates to avoid redundant univariate fits.
- Keep a toggleable reference backend for strict parity testing and add instrumentation so long-running stages are visible.

### Description

- Added native C++ helpers and kernels: `NNS_duplicate_column_map_cpp()`, `NNS_mreg_setup_cpp()`, `NNS_mreg_predict_path_v2_cpp()` (all-k v2), `NNS_mreg_predict_v2_cpp()` (single-k v2), and `NNS_xstar_path_cpp()` (Method 2 cumulative projections), and exported wrappers in `R/RcppExports.R` / `src/RcppExports.cpp`.
- Introduced R-level fast helpers and integration points: `.nns_mreg_prepare_model()` to build RPM without calling full `NNS.reg()`, `.nns_reg_partition_points_fast()` and `.nns_reg_univariate_fast()` to produce only the partition points and point estimates needed by multivariate setup, and a native-switch wrapper usage (`getOption("NNS.native.*")`) across the stack and multivariate code.
- Rewrote the production all-k path to call `NNS_mreg_predict_path_v2_cpp()` (v2) from `R/Multivariate_Regression.R` / `R/Stack.R`, precompute rank-only components, stable-sort neighbors once, and reuse prefix statistics; added `NNS_mreg_predict_v2_cpp()` as a single-k wrapper sharing internals.
- Implemented duplicate-column detection and reuse in partition construction (representative mapping from `NNS_duplicate_column_map_cpp()`), moved interval-ID grouping and RPM reduction into `src/NNS_mreg_setup.cpp`, and added native cumulative X-star path (`src/NNS_stack_fast.cpp`) with representative candidate mapping to deduplicate Method 2 candidates.
- Added status instrumentation messages at key Method 1 stages: preparing fold design, building partitions, RPM rows/validation rows, evaluating k-range, and fold completion to make long-running phases visible.
- Added unit-test scaffolding and benchmark harness files (under `tests/testthat` and `benchmarks/`) that exercise native vs reference parity and the representative Method 1 example; these tests are committed but not executed in this environment.
- Files changed: `R/Multivariate_Regression.R`, `R/Regression.R`, `R/Stack.R`, `R/RcppExports.R`, `src/NNS_mreg_predict.cpp`, `src/NNS_mreg_setup.cpp`, `src/NNS_stack_fast.cpp`, `src/RcppExports.cpp`, plus tests and benchmark placeholders.

### Testing

- Performed repository-level static checks and prepare actions: `git diff --check` passed and the changes were committed on branch `codex/stack-maximum-native-performance` (commit `e706ae3beecc4e100fc77edc24fc4a369dcbcbcd`).
- Added a suite of smoke parity tests and a benchmark harness (files under `tests/testthat/` and `benchmarks/`) to be executed in an R-capable environment; these tests include Method 1 and Method 2 parity smoke cases, xstar path checks, duplicate-column setup checks, and the v2 all-k path equivalence check.
- Automated R-level validation (e.g. `Rcpp::compileAttributes()`, `devtools::test()`, `devtools::check()`, vignette builds, and the runtime benchmarks) could not be executed here because `R` / `Rscript` is not available in this execution container; the harness and tests are in place for those runs on a properly provisioned CI or development machine.
- Notes on remaining work: the committed native v2 kernel reduces hot work and duplicates but the container-run tests and full multithreaded determinism checks remain to be executed; the code contains TODO areas (documented in the rollout) to finish per-worker thread-limited parallelization and to remove remaining per-k allocations in the hottest loops during an R-capable CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a549168e628832d822d175f5f0a0d60)