### PR TITLE
Accept duplicate predictor columns in NNS.stack and NNS.boost

### DIFF
--- a/R/Boost.R
+++ b/R/Boost.R
@@ -95,9 +95,11 @@ NNS.boost <- function(IVs.train,
     if (is.null(names(x)) || any(names(x) == "")) {
       names(x) <- paste0("X", seq_len(ncol(x)))
     }
-    if (anyDuplicated(names(x))) {
-      stop("[IVs.train] predictor names must be unique.", call. = FALSE)
-    }
+    # De-duplicate repeated predictor names with make.unique() exactly as
+    # NNS.reg's .nns_reg_as_frame() does, so the cbind(x, x) dimension trick
+    # works in NNS.boost instead of erroring. c("x", "x") becomes
+    # c("x", "x.1").
+    names(x) <- make.unique(names(x), sep = ".")
     x
   }
 
@@ -145,9 +147,10 @@ NNS.boost <- function(IVs.train,
     if (!had_column_names) {
       names(x) <- train_names
     } else {
-      if (anyDuplicated(names(x))) {
-        stop("[IVs.test] predictor names must be unique.", call. = FALSE)
-      }
+      # Normalize duplicate names with make.unique() identically to the
+      # training frame (and to NNS.reg), so cbind(x, x) test input aligns
+      # with the c("x", "x.1") training columns rather than erroring.
+      names(x) <- make.unique(names(x), sep = ".")
       missing_names <- setdiff(train_names, names(x))
       extra_names <- setdiff(names(x), train_names)
       if (length(missing_names) || length(extra_names)) {

--- a/R/Stack.R
+++ b/R/Stack.R
@@ -121,9 +121,11 @@ NNS.stack <- function(IVs.train,
     if (is.null(names(x)) || any(names(x) == "")) {
       names(x) <- paste0("X", seq_len(ncol(x)))
     }
-    if (anyDuplicated(names(x))) {
-      stop("[IVs.train] predictor names must be unique.", call. = FALSE)
-    }
+    # De-duplicate repeated predictor names with make.unique() exactly as
+    # NNS.reg's .nns_reg_as_frame() does, so the cbind(x, x) dimension trick
+    # works in NNS.stack instead of erroring. c("x", "x") becomes
+    # c("x", "x.1").
+    names(x) <- make.unique(names(x), sep = ".")
     x
   }
   
@@ -172,9 +174,10 @@ NNS.stack <- function(IVs.train,
     if (!had_names) {
       names(x) <- train_names
     } else {
-      if (anyDuplicated(names(x))) {
-        stop("[IVs.test] predictor names must be unique.", call. = FALSE)
-      }
+      # Normalize duplicate names with make.unique() identically to the
+      # training frame (and to NNS.reg), so cbind(x, x) test input aligns
+      # with the c("x", "x.1") training columns rather than erroring.
+      names(x) <- make.unique(names(x), sep = ".")
       missing_names <- setdiff(train_names, names(x))
       extra_names <- setdiff(names(x), train_names)
       if (length(missing_names) || length(extra_names)) {

--- a/tests/testthat/test-boost-duplicate-predictors.R
+++ b/tests/testthat/test-boost-duplicate-predictors.R
@@ -1,0 +1,16 @@
+test_that("NNS.boost accepts duplicate predictor columns like NNS.reg (cbind(x, x))", {
+  set.seed(123)
+  x <- rnorm(60)
+  y <- as.numeric(x > 0)
+  train <- cbind(x, x)
+
+  # Same cbind(x, x) dimension trick as NNS.reg; NNS.boost must not error with
+  # "[IVs.train] predictor names must be unique." any more, and duplicate-named
+  # test columns must align rather than error.
+  expect_error(
+    NNS.boost(IVs.train = train, DV.train = y, IVs.test = train[1:5, ],
+              learner.trials = 5, epochs = 5, CV.size = 0.25,
+              status = FALSE),
+    NA
+  )
+})

--- a/tests/testthat/test-stack-duplicate-predictors.R
+++ b/tests/testthat/test-stack-duplicate-predictors.R
@@ -1,0 +1,24 @@
+test_that("NNS.stack accepts duplicate predictor columns like NNS.reg (cbind(x, x))", {
+  set.seed(123)
+  x <- rnorm(100); y <- rnorm(100)
+
+  # The cbind(x, x) dimension trick works for NNS.reg; NNS.stack must not
+  # error with "[IVs.train] predictor names must be unique." any more.
+  expect_error(NNS.reg(x = cbind(x, x), y = y, plot = FALSE), NA)
+  res <- NNS.stack(IVs.train = cbind(x, x), DV.train = y,
+                   method = 1, ncores = 1, folds = 2, status = FALSE)
+  expect_type(res, "list")
+  expect_true("reg" %in% names(res))
+})
+
+test_that("NNS.stack aligns duplicate-named test columns (cbind(x, x)) instead of erroring", {
+  set.seed(123)
+  x <- rnorm(60); y <- rnorm(60)
+  train <- cbind(x, x)
+
+  expect_error(
+    NNS.stack(IVs.train = train, DV.train = y, IVs.test = train[1:5, ],
+              method = 1, ncores = 1, folds = 2, status = FALSE),
+    NA
+  )
+})


### PR DESCRIPTION
The cbind(x, x) increased-dimension trick works for NNS.reg but NNS.stack (and NNS.boost) rejected it with '[IVs.train] predictor names must be unique.' NNS.reg's .nns_reg_as_frame() de-duplicates repeated names with make.unique(., sep = '.') (c('x','x') -> c('x','x.1')); Stack.R and Boost.R now do the same on both the training and test frames instead of erroring, restoring parity with NNS.reg (and with the NNS-python port, which already accepts duplicate columns).


Claude-Session: https://claude.ai/code/session_019F6ZjcfXSxZWGMuSmQGmLN