### PR TITLE
Define canonical NNS example curriculum for companion ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,8 @@
 
 
 
-[![packageversion](https://img.shields.io/badge/NNS%20version-13.1-blue.svg?style=flat-square)](https://github.com/OVVO-Financial/NNS/commits/NNS-Beta-Version)   [![Licence](https://img.shields.io/badge/licence-GPL--3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0.en.html)
-
-<h2 style="margin: 0; padding: 0; border: none; height: 40px;"></h2>
-
 # NNS
-NNS (Nonlinear Nonparametric Statistics) leverages partial moments – the fundamental [elements of variance](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Partial%20Moments%20Equivalences.md) that [asymptotically approximate the area of f(x)](https://ovvo-financial.github.io/NNS/book/numerical-integration-via-partial-moments.html) – to provide a robust foundation for nonlinear analysis while maintaining linear equivalences.  Designed for real-world data that violates symmetry, linearity, or distributional assumptions.
+NNS (Nonlinear Nonparametric Statistics) leverages partial moments – the fundamental [elements of variance](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Partial%20Moments%20Equivalences.md) that [asymptotically approximate the area of f(x)](https://ovvo-financial.github.io/NNS/book/numerical-integration-via-partial-moments.html) – to provide a robust foundation for nonlinear analysis while maintaining linear equivalences. Designed for real-world data that violates symmetry, linearity, or distributional assumptions.
 
 NNS delivers a comprehensive suite of advanced statistical techniques, including:
   - Numerical Integration & Numerical Differentiation
@@ -18,12 +14,12 @@ NNS delivers a comprehensive suite of advanced statistical techniques, including
   - Nonlinear Regression & Classification
   - ANOVA
   - Seasonality & Autoregressive Modeling
-  - Normalization 
+  - Normalization
   - Stochastic Superiority / Dominance
   - Advanced Monte Carlo Sampling
 
 
-Companion R-package and datasets to: 
+Companion R-package and datasets to:
 #### Viole, F. and Nawrocki, D. (2013) "*Nonlinear Nonparametric Statistics: Using Partial Moments*" (ISBN: 1490523995)
 
 2nd edition available here: https://ovvo-financial.github.io/NNS/book/
@@ -33,22 +29,30 @@ Companion R-package and datasets to:
 
 
 ## Current Version
-Current [![NNS](https://img.shields.io/badge/NNS--blue.svg)](https://cran.r-project.org/package=NNS) CRAN version is  [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/NNS)](https://www.r-pkg.org/badges/version/NNS)
+Current [![NNS](https://img.shields.io/badge/NNS--blue.svg)](https://cran.r-project.org/package=NNS) CRAN version is [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/NNS)](https://www.r-pkg.org/badges/version/NNS)
 
 ## Installation
-[![NNS](https://img.shields.io/badge/NNS--blue.svg)](https://cran.r-project.org/package=NNS) requires [![minimal R version](https://img.shields.io/badge/R%3E%3D-3.5.0-6666ff.svg)](https://cran.r-project.org/).  See https://cran.r-project.org/ or [![installr](https://img.shields.io/badge/installr-0.18.0-blue.svg)](https://cran.r-project.org/package=installr) for upgrading to latest R release.
+[![NNS](https://img.shields.io/badge/NNS--blue.svg)](https://cran.r-project.org/package=NNS) requires [![minimal R version](https://img.shields.io/badge/R%3E%3D-3.5.0-6666ff.svg)](https://cran.r-project.org/). See https://cran.r-project.org/ or [![installr](https://img.shields.io/badge/installr-0.18.0-blue.svg)](https://cran.r-project.org/package=installr) for upgrading to the latest R release.
 
 ```r
 library(remotes); remotes::install_github('OVVO-Financial/NNS', ref = "NNS-Beta-Version")
 ```
+
 or via CRAN
+
 ```r
 install.packages('NNS')
 ```
 
 ## Examples
-Please see https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/index.md for basic partial moments equivalences, hands-on statistics, machine learning and econometrics examples.
+The nine numbered files under [`vignettes/`](vignettes/) are the canonical NNS
+example curriculum and the source of truth for companion language ports.
+Python follows the same 01–09 sequence while using Python-native syntax and
+containers.
 
+See [`examples/index.md`](examples/index.md) for the canonical cross-language
+mapping plus applied studies in statistics, regression, machine learning,
+forecasting, and econometrics.
 
 ## Citation
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,111 +1,25 @@
-# NNS
-NNS (Nonlinear Nonparametric Statistics) leverages partial moments – the fundamental [elements of variance](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Partial%20Moments%20Equivalences.md) that [asymptotically approximate the area of f(x)](https://ovvo-financial.github.io/NNS/book/numerical-integration-via-partial-moments.html) – to provide a robust foundation for nonlinear analysis while maintaining linear equivalences.  Designed for real-world data that violates symmetry, linearity, or distributional assumptions.
+# NNS examples
 
-NNS delivers a comprehensive suite of advanced statistical techniques, including:
-  - Numerical Integration & Numerical Differentiation
-  - Partitional & Hierarchical Clustering
-  - Nonlinear Correlation & Dependence
-  - Causal Analysis
-  - Nonlinear Regression & Classification
-  - ANOVA
-  - Seasonality & Autoregressive Modeling
-  - Normalization 
-  - Stochastic Superiority / Dominance
+The numbered package vignettes are the canonical NNS example curriculum. The R
+package defines the statistical narrative, datasets, section order, and
+interpretation; companion implementations should follow it.
 
-See the following for NNS detailed examples and specific applications:
+| # | Topic | R vignette | Python companion |
+|---|---|---|---|
+| 01 | Overview | `NNSvignette_01_Overview.Rmd` | `01_overview.py` |
+| 02 | Partial Moments | `NNSvignette_02_Partial_Moments.Rmd` | `02_partial_moments.py` |
+| 03 | Correlation and Dependence | `NNSvignette_03_Correlation_and_Dependence.Rmd` | `03_correlation_and_dependence.py` |
+| 04 | Normalization and Rescaling | `NNSvignette_04_Normalization_and_Rescaling.Rmd` | `04_normalization_and_rescaling.py` |
+| 05 | Sampling and Simulation | `NNSvignette_05_Sampling.Rmd` | `05_sampling_and_simulation.py` |
+| 06 | Comparing Distributions | `NNSvignette_06_Comparing_Distributions.Rmd` | `06_comparing_distributions.py` |
+| 07 | Clustering and Regression | `NNSvignette_07_Clustering_and_Regression.Rmd` | `07_clustering_and_regression.py` |
+| 08 | Classification | `NNSvignette_08_Classification.Rmd` | `08_classification.py` |
+| 09 | Forecasting | `NNSvignette_09_Forecasting.Rmd` | `09_forecasting.py` |
 
-# 1. Basic Statistics
+Canonical changes should be made in the corresponding file under `vignettes/`
+first. Python may use language-appropriate syntax and containers, but should
+preserve the same statistical demonstration and interpretation.
 
-   1.1 [Partial Moment Equivalences](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Partial%20Moments%20Equivalences.md)
-   
-   1.2 [Bayes' Theorem](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Bayes'%20Theorem%20From%20Partial%20Moments.pdf)
-
-   1.3 [CDFs and ANOVA](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Continuous_CDFs_and_ANOVA_with_NNS.pdf)
-   
-   1.4 [Bias and Confidence Intervals](https://ovvo-financial.github.io/NNS/examples/Bias_and_CI.html)
-
-   1.5 [Correlation and Dependence](https://cran.r-project.org/package=NNS/vignettes/NNSvignette_Correlation_and_Dependence.html)
-
-   1.6 [Normalization](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Normalization.pdf)
-
-   1.7 [Partial Moments Estimation Error](https://github.com/OVVO-Financial/Finance/blob/main/Data/Estimation_Error_Replication.md)
-
-
-# 2. Regression
-   
-   2.1 [Overview](https://ssrn.com/abstract=3389938)
-   
-   2.2 [Curve Fitting](https://ovvo-financial.github.io/NNS/examples/Curve_Fitting.html)
-   
-   2.3 [Nonparametric Regression Using Clusters](http://rdcu.be/tz0J)
-   
-   2.4 [Clustering and Curve Fitting By Line Segments](https://ssrn.com/abstract=2861339)
-   
-   2.5 [Regression Residuals](https://ovvo-financial.github.io/NNS/examples/Regression_Residuals.html)
-   
-   2.6 [Multiple Imputation](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/NNS_MI_vs_MICE.md)  
-
-   2.7 [Logistic Regression Binary Classification](https://ovvo-financial.github.io/NNS/examples/Logistic_Comparison.html)
-   
-   2.8 [Boston Housing](https://ovvo-financial.github.io/NNS/examples/Boston_Housing.html)
-
-   
-
-# 3. Machine Learning
-   3.1 [Partitional Estimation Using Partial Moments](https://ssrn.com/abstract=3592491)
-
-   3.2 [NNS Regression in Machine Learning](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Machine_Learning.pdf)
-
-   3.3 [Classification Using NNS Clustering Analysis](https://ssrn.com/abstract=2864711)
-   
-   3.4 [NNS vs. xgboost](https://ovvo-financial.github.io/NNS/examples/xgboost_example.html)
-   
-   3.5 [Time-Series Classification](https://ovvo-financial.github.io/NNS/examples/Time_Series_Classification.html)
-   
-   3.6 [Time-Series Classification II](https://ovvo-financial.github.io/NNS/examples/Time_Series_Classification_Expanded.html)
-
-   3.7 [Spiral Matching Example](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Spiral%20Matching%20Example.pdf)
-   
-   3.8 [MNIST](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/NNS%20vs%20KNN%20MNIST%20dataset.pdf)
-
-
-# 4. Time-Series Forecasting
-
-   4.1 [Overview](https://ssrn.com/abstract=3382300)
-   
-   4.2 [NNS vs. KERAS](https://ovvo-financial.github.io/NNS/examples/Sunspots_example.html)
-
-   4.3 [NNS vs. prophet](https://ovvo-financial.github.io/NNS/examples/prophet_NNS_comparison.html)
-   
-   4.4 [Tides](https://ovvo-financial.github.io/NNS/examples/tides.html)
-
-   4.5 [NNS vs. N-HiTS](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/NNS.ARMA%20vs%20N-Hits.md)
-
-   4.6 [NNS Time-Series Prediction Interval Benchmark](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/nns_arma_conformal_benchmark_report.md)
-
-
-# 5. Econometrics
-
-   5.1 [Econometrics Critiques and Solutions](https://ovvo-financial.github.io/NNS/examples/7_Econometric_Reasons.html)
-   
-   5.2 [VAR Alternative](https://ovvo-financial.github.io/NNS/examples/VAR_example.html)
-   
-   5.3 [NOWCASTING](https://ssrn.com/abstract=3589816)
-   
-   5.4 [Causal Analysis](https://ovvo-financial.github.io/NNS/examples/PWT.html)
-   
-   5.5 [Federal Reserve Causal Analysis](https://ovvo-financial.github.io/NNS/examples/Causal_Inference_Amongst_Macroeconomic_Variables_Using_NNS.html)
-      
-   5.6 [Causal Inference](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Causal_Inference_with_NNS_stack.pdf) 
-
-
-# References
-
-The previous examples are just that...examples.  They are not meant to serve as proofs or intended to be exhaustive demonstrations, rather the hands-on application of a robust nonparametric regression in many different types of common machine learning problems.
-
-See the [book](https://ovvo-financial.github.io/NNS/book/) or the [papers available on SSRN](https://papers.ssrn.com/sol3/cf_dev/AbsByAuth.cfm?per_id=1421356), if you'd like to learn *why* & *how* NNS does what it does.
-
-
-# Thank you for your interest in NNS!
-
-
+See [`index.md`](index.md) for applied studies, comparison papers, and extended
+examples. Those applications supplement rather than replace the canonical
+numbered curriculum.

--- a/examples/index.md
+++ b/examples/index.md
@@ -1,115 +1,87 @@
 <img src="https://github.com/OVVO-Financial/NNS/raw/NNS-Beta-Version/vignettes/images/NNS_hex_sticker.png" width="150" style="border: none; outline: none; margin: 0; padding: 0; display: block;"/>
 
+# NNS examples
 
-# NNS
-NNS (Nonlinear Nonparametric Statistics) leverages partial moments – the fundamental [elements of variance](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Partial%20Moments%20Equivalences.md) that [asymptotically approximate the area of f(x)](https://ovvo-financial.github.io/NNS/book/numerical-integration-via-partial-moments.html) – to provide a robust foundation for nonlinear analysis while maintaining linear equivalences.  Designed for real-world data that violates symmetry, linearity, or distributional assumptions.
+The numbered package vignettes are the **canonical NNS example curriculum**.
+They define the statistical narrative, section order, datasets, and intended
+interpretation for companion implementations. The Python package follows this
+sequence and treats R as the source of truth.
 
-NNS delivers a comprehensive suite of advanced statistical techniques, including: 
-  - Numerical Integration & Numerical Differentiation
-  - Partitional & Hierarchical Clustering
-  - Nonlinear Correlation & Dependence
-  - Causal Analysis
-  - Nonlinear Regression & Classification
-  - ANOVA
-  - Seasonality & Autoregressive Modeling
-  - Normalization 
-  - Stochastic Superiority / Dominance
+## Canonical package vignettes
 
-See the following for NNS detailed examples and specific applications:
+| # | Topic | R vignette | Python companion |
+|---|---|---|---|
+| 01 | Overview | [Overview](../vignettes/NNSvignette_01_Overview.Rmd) | `01_overview.py` |
+| 02 | Partial Moments | [Partial Moments](../vignettes/NNSvignette_02_Partial_Moments.Rmd) | `02_partial_moments.py` |
+| 03 | Correlation and Dependence | [Correlation and Dependence](../vignettes/NNSvignette_03_Correlation_and_Dependence.Rmd) | `03_correlation_and_dependence.py` |
+| 04 | Normalization and Rescaling | [Normalization and Rescaling](../vignettes/NNSvignette_04_Normalization_and_Rescaling.Rmd) | `04_normalization_and_rescaling.py` |
+| 05 | Sampling and Simulation | [Sampling and Simulation](../vignettes/NNSvignette_05_Sampling.Rmd) | `05_sampling_and_simulation.py` |
+| 06 | Comparing Distributions | [Comparing Distributions](../vignettes/NNSvignette_06_Comparing_Distributions.Rmd) | `06_comparing_distributions.py` |
+| 07 | Clustering and Regression | [Clustering and Regression](../vignettes/NNSvignette_07_Clustering_and_Regression.Rmd) | `07_clustering_and_regression.py` |
+| 08 | Classification | [Classification](../vignettes/NNSvignette_08_Classification.Rmd) | `08_classification.py` |
+| 09 | Forecasting | [Forecasting](../vignettes/NNSvignette_09_Forecasting.Rmd) | `09_forecasting.py` |
 
-# 1. Basic Statistics
+Canonical changes should be made in the R vignette first. A companion port may
+use language-appropriate syntax and containers, but should preserve the same
+statistical demonstration and interpretation.
 
-   1.1 [Partial Moment Equivalences](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Partial%20Moments%20Equivalences.md)
-   
-   1.2 [Bayes' Theorem](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Bayes'%20Theorem%20From%20Partial%20Moments.pdf)
+## Applied studies and extended examples
 
-   1.3 [CDFs and ANOVA](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Continuous_CDFs_and_ANOVA_with_NNS.pdf)
-   
-   1.4 [Bias and Confidence Intervals](https://ovvo-financial.github.io/NNS/examples/Bias_and_CI.html)
+The following material applies NNS to specific problems, comparisons, and
+research questions. These examples are useful applications, but they do not
+replace the numbered package curriculum.
 
-   1.5 [Correlation and Dependence](https://cran.r-project.org/package=NNS/vignettes/NNSvignette_Correlation_and_Dependence.html)
+### Basic statistics
 
-   1.6 [Normalization](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Normalization.pdf)
+1. [Partial Moment Equivalences](Partial%20Moments%20Equivalences.md)
+2. [Bayes' Theorem](Bayes'%20Theorem%20From%20Partial%20Moments.pdf)
+3. [CDFs and ANOVA](Continuous_CDFs_and_ANOVA_with_NNS.pdf)
+4. [Bias and Confidence Intervals](https://ovvo-financial.github.io/NNS/examples/Bias_and_CI.html)
+5. [Partial Moments Estimation Error](https://github.com/OVVO-Financial/Finance/blob/main/Data/Estimation_Error_Replication.md)
 
-   1.7 [Partial Moments Estimation Error](https://github.com/OVVO-Financial/Finance/blob/main/Data/Estimation_Error_Replication.md)
+### Regression
 
+1. [Overview](https://ssrn.com/abstract=3389938)
+2. [Curve Fitting](https://ovvo-financial.github.io/NNS/examples/Curve_Fitting.html)
+3. [Nonparametric Regression Using Clusters](http://rdcu.be/tz0J)
+4. [Clustering and Curve Fitting By Line Segments](https://ssrn.com/abstract=2861339)
+5. [Regression Residuals](https://ovvo-financial.github.io/NNS/examples/Regression_Residuals.html)
+6. [Multiple Imputation](NNS_MI_vs_MICE.md)
+7. [Logistic Regression Binary Classification](https://ovvo-financial.github.io/NNS/examples/Logistic_Comparison.html)
+8. [Boston Housing](https://ovvo-financial.github.io/NNS/examples/Boston_Housing.html)
 
-# 2. Regression
-   
-   2.1 [Overview](https://ssrn.com/abstract=3389938)
-   
-   2.2 [Curve Fitting](https://ovvo-financial.github.io/NNS/examples/Curve_Fitting.html)
-   
-   2.3 [Nonparametric Regression Using Clusters](http://rdcu.be/tz0J)
-   
-   2.4 [Clustering and Curve Fitting By Line Segments](https://ssrn.com/abstract=2861339)
-   
-   2.5 [Regression Residuals](https://ovvo-financial.github.io/NNS/examples/Regression_Residuals.html)
-   
-   2.6 [Multiple Imputation](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/NNS_MI_vs_MICE.md)  
+### Machine learning
 
-   2.7 [Logistic Regression Binary Classification](https://ovvo-financial.github.io/NNS/examples/Logistic_Comparison.html)
-   
-   2.8 [Boston Housing](https://ovvo-financial.github.io/NNS/examples/Boston_Housing.html)
+1. [Partitional Estimation Using Partial Moments](https://ssrn.com/abstract=3592491)
+2. [NNS Regression in Machine Learning](Machine_Learning.pdf)
+3. [Classification Using NNS Clustering Analysis](https://ssrn.com/abstract=2864711)
+4. [NNS vs. xgboost](https://ovvo-financial.github.io/NNS/examples/xgboost_example.html)
+5. [Time-Series Classification](https://ovvo-financial.github.io/NNS/examples/Time_Series_Classification.html)
+6. [Time-Series Classification II](https://ovvo-financial.github.io/NNS/examples/Time_Series_Classification_Expanded.html)
+7. [Spiral Matching Example](Spiral%20Matching%20Example.pdf)
+8. [MNIST](NNS%20vs%20KNN%20MNIST%20dataset.pdf)
 
-   
+### Time-series forecasting
 
-# 3. Machine Learning
-   3.1 [Partitional Estimation Using Partial Moments](https://ssrn.com/abstract=3592491)
+1. [Overview](https://ssrn.com/abstract=3382300)
+2. [NNS vs. KERAS](https://ovvo-financial.github.io/NNS/examples/Sunspots_example.html)
+3. [NNS vs. prophet](https://ovvo-financial.github.io/NNS/examples/prophet_NNS_comparison.html)
+4. [Tides](https://ovvo-financial.github.io/NNS/examples/tides.html)
+5. [NNS vs. N-HiTS](NNS.ARMA%20vs%20N-Hits.md)
+6. [NNS Time-Series Prediction Interval Benchmark](nns_arma_conformal_benchmark_report.md)
 
-   3.2 [NNS Regression in Machine Learning](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Machine_Learning.pdf)
+### Econometrics
 
-   3.3 [Classification Using NNS Clustering Analysis](https://ssrn.com/abstract=2864711)
-   
-   3.4 [NNS vs. xgboost](https://ovvo-financial.github.io/NNS/examples/xgboost_example.html)
-   
-   3.5 [Time-Series Classification](https://ovvo-financial.github.io/NNS/examples/Time_Series_Classification.html)
-   
-   3.6 [Time-Series Classification II](https://ovvo-financial.github.io/NNS/examples/Time_Series_Classification_Expanded.html)
+1. [Econometrics Critiques and Solutions](https://ovvo-financial.github.io/NNS/examples/7_Econometric_Reasons.html)
+2. [VAR Alternative](https://ovvo-financial.github.io/NNS/examples/VAR_example.html)
+3. [Nowcasting](https://ssrn.com/abstract=3589816)
+4. [Causal Analysis](https://ovvo-financial.github.io/NNS/examples/PWT.html)
+5. [Federal Reserve Causal Analysis](https://ovvo-financial.github.io/NNS/examples/Causal_Inference_Amongst_Macroeconomic_Variables_Using_NNS.html)
+6. [Causal Inference](Causal_Inference_with_NNS_stack.pdf)
 
-   3.7 [Spiral Matching Example](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Spiral%20Matching%20Example.pdf)
-   
-   3.8 [MNIST](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/NNS%20vs%20KNN%20MNIST%20dataset.pdf)
+## References
 
-
-# 4. Time-Series Forecasting
-
-   4.1 [Overview](https://ssrn.com/abstract=3382300)
-   
-   4.2 [NNS vs. KERAS](https://ovvo-financial.github.io/NNS/examples/Sunspots_example.html)
-
-   4.3 [NNS vs. prophet](https://ovvo-financial.github.io/NNS/examples/prophet_NNS_comparison.html)
-   
-   4.4 [Tides](https://ovvo-financial.github.io/NNS/examples/tides.html)
-
-   4.5 [NNS vs. N-HiTS](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/NNS.ARMA%20vs%20N-Hits.md)
-
-   4.6 [NNS Time-Series Prediction Interval Benchmark](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/nns_arma_conformal_benchmark_report.md)
-
-
-# 5. Econometrics
-
-   5.1 [Econometrics Critiques and Solutions](https://ovvo-financial.github.io/NNS/examples/7_Econometric_Reasons.html)
-   
-   5.2 [VAR Alternative](https://ovvo-financial.github.io/NNS/examples/VAR_example.html)
-   
-   5.3 [NOWCASTING](https://ssrn.com/abstract=3589816)
-   
-   5.4 [Causal Analysis](https://ovvo-financial.github.io/NNS/examples/PWT.html)
-   
-   5.5 [Federal Reserve Causal Analysis](https://ovvo-financial.github.io/NNS/examples/Causal_Inference_Amongst_Macroeconomic_Variables_Using_NNS.html)
-
-   5.6 [Causal Inference](https://github.com/OVVO-Financial/NNS/blob/NNS-Beta-Version/examples/Causal_Inference_with_NNS_stack.pdf)
-   
-    
-
-# References
-
-The previous examples are just that...examples.  They are not meant to serve as proofs or intended to be exhaustive demonstrations, rather the hands-on application of a robust nonparametric regression in many different types of common machine learning problems.
-
-See the [book](https://ovvo-financial.github.io/NNS/book/) or the [papers available on SSRN](https://papers.ssrn.com/sol3/cf_dev/AbsByAuth.cfm?per_id=1421356), if you'd like to learn *why* & *how* NNS does what it does.
-
-
-# Thank you for your interest in NNS!
-
-
+The applied examples are demonstrations rather than exhaustive proofs. See the
+[book](https://ovvo-financial.github.io/NNS/book/) and the
+[research papers](https://papers.ssrn.com/sol3/cf_dev/AbsByAuth.cfm?per_id=1421356)
+for the underlying arguments.


### PR DESCRIPTION
## What changed

- Declared the nine numbered R vignettes as the canonical NNS example curriculum.
- Added the explicit 01-09 R-to-Python topic mapping to the example index.
- Separated canonical package vignettes from applied studies, papers, and comparison examples.
- Updated the root README and examples README so future cross-language additions begin in R.

## Why

The R package has the decade-long implementation history and should define the statistical narrative, terminology, datasets, and interpretation for companion ports. Previously the example index mixed canonical package instruction with external applied examples, making the source-of-truth relationship unclear.

## Impact

No package code or statistical behavior changes. This is documentation and example-governance only.

## Validation

- Reviewed the branch diff against `NNS-Beta-Version`.
- Confirmed changes are limited to `README.md`, `examples/README.md`, and `examples/index.md`.
