### PR TITLE
Add GitHub Pages site staging for examples with styling

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -56,21 +56,8 @@ jobs:
           mkdir -p docs/book
           rsync -a --delete book/_book/ docs/book/
 
-      - name: Stage HTML examples for Pages
-        run: |
-          mkdir -p docs/examples
-          rsync -a --delete --include='*.html' --exclude='*' examples/ docs/examples/
-          {
-            echo '<!doctype html><html><head><meta charset="utf-8"><title>NNS Examples</title></head><body>'
-            echo '<h1>NNS Examples</h1><ul>'
-            for file in docs/examples/*.html; do
-              [ -e "$file" ] || continue
-              name=$(basename "$file")
-              title=${name%.html}
-              echo "<li><a href=\"$name\">$title</a></li>"
-            done
-            echo '</ul></body></html>'
-          } > docs/examples/index.html
+      - name: Stage examples for Pages
+        run: bash tools/stage_examples_site.sh docs/examples
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -31,3 +31,15 @@ articles:
 - title: "Applications"
   contents:
   - NNSvignette_09_Forecasting
+
+navbar:
+  structure:
+    left: [intro, reference, articles, examples, book]
+    right: [search, github]
+  components:
+    examples:
+      text: Examples
+      href: https://ovvo-financial.github.io/NNS/examples/
+    book:
+      text: Book
+      href: https://ovvo-financial.github.io/NNS/book/

--- a/examples/index.md
+++ b/examples/index.md
@@ -11,15 +11,15 @@ sequence and treats R as the source of truth.
 
 | # | Topic | R vignette | Python companion |
 |---|---|---|---|
-| 01 | Overview | [Overview](../vignettes/NNSvignette_01_Overview.Rmd) | `01_overview.py` |
-| 02 | Partial Moments | [Partial Moments](../vignettes/NNSvignette_02_Partial_Moments.Rmd) | `02_partial_moments.py` |
-| 03 | Correlation and Dependence | [Correlation and Dependence](../vignettes/NNSvignette_03_Correlation_and_Dependence.Rmd) | `03_correlation_and_dependence.py` |
-| 04 | Normalization and Rescaling | [Normalization and Rescaling](../vignettes/NNSvignette_04_Normalization_and_Rescaling.Rmd) | `04_normalization_and_rescaling.py` |
-| 05 | Sampling and Simulation | [Sampling and Simulation](../vignettes/NNSvignette_05_Sampling.Rmd) | `05_sampling_and_simulation.py` |
-| 06 | Comparing Distributions | [Comparing Distributions](../vignettes/NNSvignette_06_Comparing_Distributions.Rmd) | `06_comparing_distributions.py` |
-| 07 | Clustering and Regression | [Clustering and Regression](../vignettes/NNSvignette_07_Clustering_and_Regression.Rmd) | `07_clustering_and_regression.py` |
-| 08 | Classification | [Classification](../vignettes/NNSvignette_08_Classification.Rmd) | `08_classification.py` |
-| 09 | Forecasting | [Forecasting](../vignettes/NNSvignette_09_Forecasting.Rmd) | `09_forecasting.py` |
+| 01 | Overview | [Overview](https://ovvo-financial.github.io/NNS/articles/NNSvignette_01_Overview.html) | [`01_overview.py`](https://github.com/OVVO-Financial/NNS-python/blob/main/examples/vignettes/01_overview.py) |
+| 02 | Partial Moments | [Partial Moments](https://ovvo-financial.github.io/NNS/articles/NNSvignette_02_Partial_Moments.html) | [`02_partial_moments.py`](https://github.com/OVVO-Financial/NNS-python/blob/main/examples/vignettes/02_partial_moments.py) |
+| 03 | Correlation and Dependence | [Correlation and Dependence](https://ovvo-financial.github.io/NNS/articles/NNSvignette_03_Correlation_and_Dependence.html) | [`03_correlation_and_dependence.py`](https://github.com/OVVO-Financial/NNS-python/blob/main/examples/vignettes/03_correlation_and_dependence.py) |
+| 04 | Normalization and Rescaling | [Normalization and Rescaling](https://ovvo-financial.github.io/NNS/articles/NNSvignette_04_Normalization_and_Rescaling.html) | [`04_normalization_and_rescaling.py`](https://github.com/OVVO-Financial/NNS-python/blob/main/examples/vignettes/04_normalization_and_rescaling.py) |
+| 05 | Sampling and Simulation | [Sampling and Simulation](https://ovvo-financial.github.io/NNS/articles/NNSvignette_05_Sampling.html) | [`05_sampling_and_simulation.py`](https://github.com/OVVO-Financial/NNS-python/blob/main/examples/vignettes/05_sampling_and_simulation.py) |
+| 06 | Comparing Distributions | [Comparing Distributions](https://ovvo-financial.github.io/NNS/articles/NNSvignette_06_Comparing_Distributions.html) | [`06_comparing_distributions.py`](https://github.com/OVVO-Financial/NNS-python/blob/main/examples/vignettes/06_comparing_distributions.py) |
+| 07 | Clustering and Regression | [Clustering and Regression](https://ovvo-financial.github.io/NNS/articles/NNSvignette_07_Clustering_and_Regression.html) | [`07_clustering_and_regression.py`](https://github.com/OVVO-Financial/NNS-python/blob/main/examples/vignettes/07_clustering_and_regression.py) |
+| 08 | Classification | [Classification](https://ovvo-financial.github.io/NNS/articles/NNSvignette_08_Classification.html) | [`08_classification.py`](https://github.com/OVVO-Financial/NNS-python/blob/main/examples/vignettes/08_classification.py) |
+| 09 | Forecasting | [Forecasting](https://ovvo-financial.github.io/NNS/articles/NNSvignette_09_Forecasting.html) | [`09_forecasting.py`](https://github.com/OVVO-Financial/NNS-python/blob/main/examples/vignettes/09_forecasting.py) |
 
 Canonical changes should be made in the R vignette first. A companion port may
 use language-appropriate syntax and containers, but should preserve the same

--- a/examples/pages.css
+++ b/examples/pages.css
@@ -1,0 +1,97 @@
+/* Styling for the rendered NNS examples pages on GitHub Pages. */
+:root {
+  --nns-text: #1f2430;
+  --nns-muted: #5a6472;
+  --nns-accent: #2780e3;
+  --nns-border: #e3e7ee;
+  --nns-code-bg: #f5f7fa;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  max-width: 52rem;
+  font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.65;
+  color: var(--nns-text);
+  background: #ffffff;
+}
+
+h1, h2, h3, h4 {
+  line-height: 1.25;
+  margin: 2rem 0 0.75rem;
+  font-weight: 650;
+}
+
+h1 { font-size: 2rem; margin-top: 0.5rem; }
+h2 { font-size: 1.5rem; border-bottom: 1px solid var(--nns-border); padding-bottom: 0.3rem; }
+h3 { font-size: 1.2rem; }
+
+a { color: var(--nns-accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+img { max-width: 100%; height: auto; }
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1rem 0;
+  font-size: 0.95rem;
+  display: block;
+  overflow-x: auto;
+}
+
+th, td {
+  border: 1px solid var(--nns-border);
+  padding: 0.45rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th { background: var(--nns-code-bg); }
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9em;
+  background: var(--nns-code-bg);
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+}
+
+pre {
+  background: var(--nns-code-bg);
+  border: 1px solid var(--nns-border);
+  border-radius: 6px;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+}
+
+pre code { background: none; padding: 0; }
+
+blockquote {
+  margin: 1rem 0;
+  padding: 0.25rem 1rem;
+  border-left: 4px solid var(--nns-border);
+  color: var(--nns-muted);
+}
+
+ol, ul { padding-left: 1.5rem; }
+li { margin: 0.25rem 0; }
+
+hr { border: none; border-top: 1px solid var(--nns-border); margin: 2rem 0; }
+
+.nns-site-nav {
+  font-size: 0.95rem;
+  color: var(--nns-muted);
+  border-bottom: 1px solid var(--nns-border);
+  padding-bottom: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.nns-site-nav a { margin-right: 1.25rem; }

--- a/tools/stage_examples_site.sh
+++ b/tools/stage_examples_site.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Stage the examples/ directory as a browsable GitHub Pages section.
+#
+# Copies the published artifact formats (html, pdf, images) verbatim, renders
+# every Markdown study to styled standalone HTML with pandoc, and renders
+# examples/index.md as the landing page. Relative *.md links are rewritten to
+# *.html so the curated index works on the deployed site while staying a
+# normal Markdown document in the repository.
+#
+# Usage: tools/stage_examples_site.sh <output-directory>
+
+set -euo pipefail
+
+OUT="${1:?usage: tools/stage_examples_site.sh <output-directory>}"
+SRC="examples"
+SITE_ROOT="https://ovvo-financial.github.io/NNS"
+
+command -v pandoc >/dev/null || { echo "pandoc is required" >&2; exit 1; }
+
+mkdir -p "$OUT"
+
+rsync -a --delete \
+  --include='*.html' --include='*.pdf' \
+  --include='*.png' --include='*.jpg' --include='*.css' \
+  --exclude='*' "$SRC/" "$OUT/"
+
+# Shared navigation strip injected above every rendered Markdown page.
+NAV_FILE="$(mktemp)"
+cat > "$NAV_FILE" <<NAV
+<nav class="nns-site-nav">
+  <a href="$SITE_ROOT/">NNS home</a>
+  <a href="$SITE_ROOT/examples/">Examples</a>
+  <a href="$SITE_ROOT/book/">Book</a>
+  <a href="https://github.com/OVVO-Financial/NNS">GitHub</a>
+</nav>
+NAV
+trap 'rm -f "$NAV_FILE"' EXIT
+
+render_markdown() {
+  local source="$1" target="$2" title="$3"
+  # Point relative Markdown links at their rendered pages. Links containing
+  # ':' (absolute URLs) are left untouched.
+  sed -E 's/\(([^):]*)\.md\)/(\1.html)/g' "$source" | pandoc \
+    --from gfm \
+    --to html5 \
+    --standalone \
+    --css=pages.css \
+    --metadata pagetitle="$title" \
+    --include-before-body="$NAV_FILE" \
+    --output "$target"
+  echo "rendered: $target"
+}
+
+while IFS= read -r -d '' md; do
+  name="$(basename "$md" .md)"
+  case "$name" in
+    README|index) continue ;;
+  esac
+  render_markdown "$md" "$OUT/$name.html" "NNS examples: $name"
+done < <(find "$SRC" -maxdepth 1 -name '*.md' -print0)
+
+render_markdown "$SRC/index.md" "$OUT/index.html" "NNS Examples"
+
+echo "staged $(find "$OUT" -type f | wc -l) files into $OUT"


### PR DESCRIPTION
## Summary
This PR adds infrastructure to build and deploy a styled GitHub Pages site for the examples section, including a new stylesheet and automated staging script.

## Key Changes
- **New stylesheet** (`examples/pages.css`): Comprehensive CSS styling for rendered Markdown pages on GitHub Pages, featuring a cohesive color scheme, typography, and component styling (tables, code blocks, blockquotes, etc.)
- **New staging script** (`tools/stage_examples_site.sh`): Bash script that:
  - Copies pre-built artifacts (HTML, PDF, images, CSS) to the output directory
  - Renders all Markdown files to styled standalone HTML using pandoc
  - Injects a shared navigation bar on every rendered page
  - Rewrites relative `.md` links to `.html` for proper site navigation
  - Generates the examples landing page from `examples/index.md`
- **Updated examples index** (`examples/index.md`): Changed all relative links to absolute URLs pointing to the R vignettes on the main NNS site and Python companion scripts on GitHub
- **Updated pkgdown workflow** (`.github/workflows/pkgdown.yaml`): Replaced inline HTML generation with a call to the new staging script
- **Updated pkgdown config** (`_pkgdown.yml`): Added navbar components linking to the examples and book sections

## Implementation Details
- The staging script uses pandoc with GitHub-flavored Markdown as input and HTML5 as output
- Navigation is injected via a temporary file to maintain consistency across all rendered pages
- The script preserves the site root URL (`https://ovvo-financial.github.io/NNS`) for proper linking in the deployed environment
- CSS uses CSS custom properties for maintainable color theming
- The styling is responsive and follows modern web design practices

https://claude.ai/code/session_014q6V4fJ7zz6KLAgu3ddhDp