### PR TITLE
dy.d_: fit NNS.stack once per regressor (batch all bandwidths)

### DIFF
--- a/R/dy_d_wrt.R
+++ b/R/dy_d_wrt.R
@@ -158,18 +158,30 @@ dy.d_ <- function(x, y, wrt,
     LPM.VaR(min(1, p + H), 1, col) - LPM.VaR(max(0, p - H), 1, col)
   }
 
+  col <- x[, wrt]
+
   # v0.5.7 bandwidths.
   h_s <- 1/log(length(x), c(2, 10))
   h_s <- c(h_s, 10 * h_s)
-  if (NNS.dep(x[, wrt], y)$Dependence < .5) h_s <- 2 * h_s
-
-  col <- x[, wrt]
-
-  band_first <- list()
-  band_second <- list()
-  band_mixed <- list()
+  if (NNS.dep(col, y)$Dependence < .5) h_s <- 2 * h_s
 
   is_vector <- is.vector(eval.points) || (!is.null(ncol(eval.points)) && ncol(eval.points) == 1)
+
+  # The NNS.stack fit (CV n.best, dimension-reduction coefficients, blend weight)
+  # depends only on (x, y), never on the evaluation points, so every bandwidth -
+  # and the mixed-derivative corners - are predicted from a single fit. Gather
+  # every test block, run ONE NNS.stack, then slice it back.
+  chunks <- list(); csize <- integer(0)
+  push <- function(block) {
+    i <- length(chunks) + 1L
+    chunks[[i]] <<- block
+    csize[i] <<- nrow(block)
+    i
+  }
+
+  steps_per_band <- vector("list", length(h_s))
+  main_idx <- integer(length(h_s))
+  position <- NULL; id <- NULL
 
   if (is_vector) {
     eval_vec <- as.numeric(unlist(eval.points))
@@ -177,14 +189,13 @@ dy.d_ <- function(x, y, wrt,
     grid <- apply(x, 2, function(z) LPM.VaR(seq(0, 1, .05), 0, z))
     if (is.null(dim(grid)) || ncol(grid) != l) grid <- matrix(grid, ncol = l, byrow = FALSE)
     sampsize <- nrow(grid)
+    position <- rep(rep(c("l", "m", "u"), each = sampsize), times = k)
+    id <- rep(seq_len(k), each = 3L * sampsize)
 
     for (bi in seq_along(h_s)) {
       H <- h_s[bi]
       steps <- vapply(eval_vec, function(ev) dydx.step(col, ev, H), numeric(1))
-
       blocks <- vector("list", 3L * k)
-      position <- character(0)
-      id <- integer(0)
       for (g in seq_len(k)) {
         lower_g <- grid; middle_g <- grid; upper_g <- grid
         lower_g[, wrt]  <- eval_vec[g] - steps[g]
@@ -193,28 +204,9 @@ dy.d_ <- function(x, y, wrt,
         blocks[[3L * g - 2L]] <- lower_g
         blocks[[3L * g - 1L]] <- middle_g
         blocks[[3L * g]]      <- upper_g
-        position <- c(position, rep(c("l", "m", "u"), each = sampsize))
-        id <- c(id, rep(g, 3L * sampsize))
       }
-      deriv.points <- do.call(rbind, blocks)
-      colnames(deriv.points) <- colnames(x)
-      estimates <- stack.est(x, y, deriv.points)
-
-      f1 <- numeric(k); f2 <- numeric(k)
-      for (g in seq_len(k)) {
-        lo <- mean(estimates[position == "l" & id == g])
-        mm <- mean(estimates[position == "m" & id == g])
-        up <- mean(estimates[position == "u" & id == g])
-        h <- steps[g]
-        if (is.finite(h) && h != 0) {
-          f1[g] <- (up - lo) / (2 * h)
-          f2[g] <- (up - 2 * mm + lo) / (h ^ 2)
-        } else {
-          f1[g] <- NA_real_; f2[g] <- NA_real_
-        }
-      }
-      band_first[[bi]] <- f1
-      band_second[[bi]] <- f2
+      steps_per_band[[bi]] <- steps
+      main_idx[bi] <- push(do.call(rbind, blocks))
     }
     mixed_eval <- if (k == 2L) matrix(eval_vec, nrow = 1L) else NULL
 
@@ -226,25 +218,77 @@ dy.d_ <- function(x, y, wrt,
     for (bi in seq_along(h_s)) {
       H <- h_s[bi]
       steps <- vapply(seq_len(n_eval), function(i) dydx.step(col, eval_mat[i, wrt], H), numeric(1))
-      finite <- is.finite(steps) & steps != 0
-
       lower <- eval_mat; upper <- eval_mat
       lower[, wrt] <- eval_mat[, wrt] - steps
       upper[, wrt] <- eval_mat[, wrt] + steps
-      deriv.points <- rbind(lower, eval_mat, upper)
-      colnames(deriv.points) <- colnames(x)
-      estimates <- stack.est(x, y, deriv.points)
+      steps_per_band[[bi]] <- steps
+      main_idx[bi] <- push(rbind(lower, eval_mat, upper))
+    }
+    mixed_eval <- eval_mat
+  }
 
-      lo <- estimates[seq_len(n_eval)]
-      mm <- estimates[n_eval + seq_len(n_eval)]
-      up <- estimates[2L * n_eval + seq_len(n_eval)]
+  # Mixed-derivative corners (also predicted from the same single fit).
+  mixed_meta <- vector("list", length(h_s))
+  if (mixed) {
+    if (is.null(mixed_eval) || ncol(mixed_eval) != 2) stop("Mixed Derivatives are only for 2 IV")
+    for (bi in seq_along(h_s)) {
+      H <- h_s[bi]
+      corner_blocks <- list(); scales <- numeric(nrow(mixed_eval))
+      for (m in seq_len(nrow(mixed_eval))) {
+        p <- mixed_eval[m, ]
+        s1 <- dydx.step(x[, 1], p[1], H); s2 <- dydx.step(x[, 2], p[2], H)
+        if (is.finite(s1) && is.finite(s2) && s1 != 0 && s2 != 0) {
+          corner_blocks[[length(corner_blocks) + 1L]] <- rbind(
+            c(p[1] + s1, p[2] + s2), c(p[1] - s1, p[2] + s2),
+            c(p[1] + s1, p[2] - s2), c(p[1] - s1, p[2] - s2))
+          scales[m] <- 4 * s1 * s2
+        } else scales[m] <- NA_real_
+      }
+      if (length(corner_blocks)) {
+        mixed_meta[[bi]] <- list(idx = push(do.call(rbind, corner_blocks)), scales = scales)
+      } else {
+        mixed_meta[[bi]] <- list(idx = NA_integer_, scales = scales)
+      }
+    }
+  }
+
+  # ---- the single NNS.stack fit + prediction --------------------------------
+  big <- do.call(rbind, chunks)
+  colnames(big) <- colnames(x)
+  preds <- stack.est(x, y, big)
+  offs <- c(0L, cumsum(csize))
+  parts <- lapply(seq_along(csize), function(i) preds[(offs[i] + 1L):offs[i + 1L]])
+
+  band_first <- vector("list", length(h_s))
+  band_second <- vector("list", length(h_s))
+  for (bi in seq_along(h_s)) {
+    steps <- steps_per_band[[bi]]; block <- parts[[main_idx[bi]]]
+    if (is_vector) {
+      kk <- length(steps); f1 <- numeric(kk); f2 <- numeric(kk)
+      for (g in seq_len(kk)) {
+        lo <- mean(block[position == "l" & id == g])
+        mm <- mean(block[position == "m" & id == g])
+        up <- mean(block[position == "u" & id == g])
+        h <- steps[g]
+        if (is.finite(h) && h != 0) {
+          f1[g] <- (up - lo) / (2 * h)
+          f2[g] <- (up - 2 * mm + lo) / (h ^ 2)
+        } else {
+          f1[g] <- NA_real_; f2[g] <- NA_real_
+        }
+      }
+    } else {
+      n_eval <- length(steps)
+      lo <- block[seq_len(n_eval)]
+      mm <- block[n_eval + seq_len(n_eval)]
+      up <- block[2L * n_eval + seq_len(n_eval)]
+      finite <- is.finite(steps) & steps != 0
       f1 <- (up - lo) / (2 * steps)
       f2 <- (up - 2 * mm + lo) / (steps ^ 2)
       f1[!finite] <- NA_real_; f2[!finite] <- NA_real_
-      band_first[[bi]] <- f1
-      band_second[[bi]] <- f2
     }
-    mixed_eval <- eval_mat
+    band_first[[bi]] <- f1
+    band_second[[bi]] <- f2
   }
 
   row_nanmean <- function(bands) {
@@ -253,30 +297,28 @@ dy.d_ <- function(x, y, wrt,
     rowMeans(m, na.rm = TRUE)
   }
 
-  if (mixed) {
-    if (is.null(mixed_eval) || ncol(mixed_eval) != 2) stop("Mixed Derivatives are only for 2 IV")
-    for (bi in seq_along(h_s)) {
-      H <- h_s[bi]
-      vals <- vapply(seq_len(nrow(mixed_eval)), function(i) {
-        p <- mixed_eval[i, ]
-        s1 <- dydx.step(x[, 1], p[1], H)
-        s2 <- dydx.step(x[, 2], p[2], H)
-        if (!is.finite(s1) || !is.finite(s2) || s1 == 0 || s2 == 0) return(NA_real_)
-        corners <- rbind(c(p[1] + s1, p[2] + s2),
-                         c(p[1] - s1, p[2] + s2),
-                         c(p[1] + s1, p[2] - s2),
-                         c(p[1] - s1, p[2] - s2))
-        colnames(corners) <- colnames(x)
-        z <- stack.est(x, y, corners)
-        (z[1] + z[4] - z[2] - z[3]) / (4 * s1 * s2)
-      }, numeric(1))
-      band_mixed[[bi]] <- vals
-    }
-  }
-
   final_results <- list("First"  = row_nanmean(band_first),
                         "Second" = row_nanmean(band_second))
-  if (mixed) final_results$Mixed <- row_nanmean(band_mixed)
+
+  if (mixed) {
+    band_mixed <- vector("list", length(h_s))
+    for (bi in seq_along(h_s)) {
+      meta <- mixed_meta[[bi]]
+      vals <- rep(NA_real_, length(meta$scales))
+      if (!is.na(meta$idx)) {
+        z <- parts[[meta$idx]]; pos <- 0L
+        for (m in seq_along(meta$scales)) {
+          if (is.finite(meta$scales[m])) {
+            c4 <- z[(pos + 1L):(pos + 4L)]
+            vals[m] <- (c4[1] + c4[4] - c4[2] - c4[3]) / meta$scales[m]
+            pos <- pos + 4L
+          }
+        }
+      }
+      band_mixed[[bi]] <- vals
+    }
+    final_results$Mixed <- row_nanmean(band_mixed)
+  }
 
   if (messages) message("", "\r", appendLF = TRUE)
   return(final_results)


### PR DESCRIPTION
The stack fit (CV n.best, dimension-reduction coefficients, blend weight) depends only on (x, y), not on the evaluation points, so predicting each bandwidth with a separate 5-fold NNS.stack CV repeated the identical fit four times per regressor. Now every bandwidth's test block (and the mixed-derivative corners) is gathered and predicted from a SINGLE NNS.stack fit per regressor, then sliced back - a ~4x reduction in the dominant cross-validation cost for the derivative-at-a-point examples, with identical results.

Validated bug-free: under a deterministic mock engine the batched wrapper returns output identical to the previous per-bandwidth version across the vector, matrix, and mixed branches.


Claude-Session: https://claude.ai/code/session_01AxBV5HmXHY5nCUvW9SwDvb